### PR TITLE
Use ByteArrays for hashes

### DIFF
--- a/SabreTools.Library/FileTypes/CHDFile.cs
+++ b/SabreTools.Library/FileTypes/CHDFile.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using SabreTools.Library.Data;
+using SabreTools.Library.Tools;
 
 #if MONO
 using System.IO;
@@ -132,8 +133,8 @@ namespace SabreTools.Library.FileTypes
 			}
 
 			// Get the header size and version
-			m_headersize = ReadUInt32();
-			m_version = ReadUInt32();
+			m_headersize = m_br.ReadUInt32Reverse();
+			m_version = m_br.ReadUInt32Reverse();
 
 			// If we have an invalid combination of size and version
 			if ((m_version == 3 && m_headersize != Constants.CHD_V3_HEADER_SIZE)
@@ -198,7 +199,7 @@ namespace SabreTools.Library.FileTypes
 			m_mapentrybytes = 16;
 
 			// Read the CHD flags
-			uint flags = ReadUInt32();
+			uint flags = m_br.ReadUInt32Reverse();
 
 			// Determine compression
 			switch (m_br.ReadUInt32())
@@ -212,12 +213,12 @@ namespace SabreTools.Library.FileTypes
 
 			m_compression[1] = m_compression[2] = m_compression[3] = CHDCodecType.CHD_CODEC_NONE;
 
-			m_hunkcount = ReadUInt32();
-			m_logicalbytes = ReadUInt64();
-			m_metaoffset = ReadUInt32();
+			m_hunkcount = m_br.ReadUInt32Reverse();
+			m_logicalbytes = m_br.ReadUInt64Reverse();
+			m_metaoffset = m_br.ReadUInt32Reverse();
 
 			m_br.BaseStream.Seek(76, SeekOrigin.Begin);
-			m_hunkbytes = ReadUInt32();
+			m_hunkbytes = m_br.ReadUInt32Reverse();
 
 			m_br.BaseStream.Seek(Constants.CHDv3SHA1Offset, SeekOrigin.Begin);
 			sha1 = m_br.ReadBytes(20);
@@ -246,7 +247,7 @@ namespace SabreTools.Library.FileTypes
 			m_mapentrybytes = 16;
 
 			// Read the CHD flags
-			uint flags = ReadUInt32();
+			uint flags = m_br.ReadUInt32Reverse();
 
 			// Determine compression
 			switch (m_br.ReadUInt32())
@@ -260,12 +261,12 @@ namespace SabreTools.Library.FileTypes
 
 			m_compression[1] = m_compression[2] = m_compression[3] = CHDCodecType.CHD_CODEC_NONE;
 
-			m_hunkcount = ReadUInt32();
-			m_logicalbytes = ReadUInt64();
-			m_metaoffset = ReadUInt32();
+			m_hunkcount = m_br.ReadUInt32Reverse();
+			m_logicalbytes = m_br.ReadUInt64Reverse();
+			m_metaoffset = m_br.ReadUInt32Reverse();
 
 			m_br.BaseStream.Seek(44, SeekOrigin.Begin);
-			m_hunkbytes = ReadUInt32();
+			m_hunkbytes = m_br.ReadUInt32Reverse();
 
 			m_br.BaseStream.Seek(Constants.CHDv4SHA1Offset, SeekOrigin.Begin);
 			sha1 = m_br.ReadBytes(20);
@@ -289,17 +290,17 @@ namespace SabreTools.Library.FileTypes
 			byte[] sha1 = new byte[20];
 
 			// Determine compression
-			m_compression[0] = (CHDCodecType)ReadUInt32();
-			m_compression[1] = (CHDCodecType)ReadUInt32();
-			m_compression[2] = (CHDCodecType)ReadUInt32();
-			m_compression[3] = (CHDCodecType)ReadUInt32();
+			m_compression[0] = (CHDCodecType)m_br.ReadUInt32Reverse();
+			m_compression[1] = (CHDCodecType)m_br.ReadUInt32Reverse();
+			m_compression[2] = (CHDCodecType)m_br.ReadUInt32Reverse();
+			m_compression[3] = (CHDCodecType)m_br.ReadUInt32Reverse();
 
-			m_logicalbytes = ReadUInt64();
-			m_mapoffset = ReadUInt64();
-			m_metaoffset = ReadUInt64();
-			m_hunkbytes = ReadUInt32();
+			m_logicalbytes = m_br.ReadUInt64Reverse();
+			m_mapoffset = m_br.ReadUInt64Reverse();
+			m_metaoffset = m_br.ReadUInt64Reverse();
+			m_hunkbytes = m_br.ReadUInt32Reverse();
 			m_hunkcount = (m_logicalbytes + m_hunkbytes - 1) / m_hunkbytes;
-			m_unitbytes = ReadUInt32();
+			m_unitbytes = m_br.ReadUInt32Reverse();
 			m_unitcount = (m_logicalbytes + m_unitbytes - 1) / m_unitbytes;
 
 			// m_allow_writes = !compressed();
@@ -310,26 +311,6 @@ namespace SabreTools.Library.FileTypes
 			m_br.BaseStream.Seek(Constants.CHDv5SHA1Offset, SeekOrigin.Begin);
 			sha1 = m_br.ReadBytes(20);
 			return sha1;
-		}
-
-		#endregion
-
-		#region Helpers
-
-		/// <summary>
-		/// Read a proper UInt32 from the stream
-		/// </summary>
-		private uint ReadUInt32()
-		{
-			return BitConverter.ToUInt32(m_br.ReadBytes(4).Reverse().ToArray(), 0);
-		}
-
-		/// <summary>
-		/// Read a proper UInt64 from the stream
-		/// </summary>
-		private ulong ReadUInt64()
-		{
-			return BitConverter.ToUInt64(m_br.ReadBytes(8).Reverse().ToArray(), 0);
 		}
 
 		#endregion

--- a/SabreTools.Library/FileTypes/GZipArchive.cs
+++ b/SabreTools.Library/FileTypes/GZipArchive.cs
@@ -217,7 +217,7 @@ namespace SabreTools.Library.FileTypes
 					BinaryReader br = new BinaryReader(FileTools.TryOpenRead(_filename));
 					br.BaseStream.Seek(-8, SeekOrigin.End);
 					byte[] headercrc = br.ReadBytes(4);
-					tempRom.CRC = BitConverter.ToString(headercrc.Reverse().ToArray()).Replace("-", string.Empty).ToLowerInvariant();
+					tempRom.CRC = Style.ByteArrayToString(headercrc.Reverse().ToArray());
 					byte[] headersize = br.ReadBytes(4);
 					tempRom.Size = BitConverter.ToInt32(headersize.Reverse().ToArray(), 0);
 					br.Dispose();
@@ -387,8 +387,8 @@ namespace SabreTools.Library.FileTypes
 			}
 
 			// Now convert the data and get the right position
-			string gzmd5 = BitConverter.ToString(headermd5).Replace("-", string.Empty);
-			string gzcrc = BitConverter.ToString(headercrc).Replace("-", string.Empty);
+			string gzmd5 = Style.ByteArrayToString(headermd5);
+			string gzcrc = Style.ByteArrayToString(headercrc);
 			long extractedsize = (long)headersz;
 
 			Rom rom = new Rom

--- a/SabreTools.Library/FileTypes/GZipArchive.cs
+++ b/SabreTools.Library/FileTypes/GZipArchive.cs
@@ -216,10 +216,9 @@ namespace SabreTools.Library.FileTypes
 					Rom tempRom = new Rom(gamename, gamename, omitFromScan);
 					BinaryReader br = new BinaryReader(FileTools.TryOpenRead(_filename));
 					br.BaseStream.Seek(-8, SeekOrigin.End);
-					byte[] headercrc = br.ReadBytes(4);
-					tempRom.CRC = Style.ByteArrayToString(headercrc.Reverse().ToArray());
-					byte[] headersize = br.ReadBytes(4);
-					tempRom.Size = BitConverter.ToInt32(headersize.Reverse().ToArray(), 0);
+					byte[] headercrc = br.ReadBytesReverse(4);
+					tempRom.CRC = Style.ByteArrayToString(headercrc);
+					tempRom.Size = br.ReadInt32Reverse();
 					br.Dispose();
 
 					found.Add(tempRom);

--- a/SabreTools.Library/Items/Disk.cs
+++ b/SabreTools.Library/Items/Disk.cs
@@ -28,27 +28,27 @@ namespace SabreTools.Library.Items
 		// Disk information
 		public string MD5
 		{
-			get { return Style.ByteArrayToString(_md5); }
+			get { return _md5.IsNullOrEmpty() ? null : Style.ByteArrayToString(_md5); }
 			set { _md5 = Style.StringToByteArray(value); }
 		}
 		public string SHA1
 		{
-			get { return Style.ByteArrayToString(_sha1); }
+			get { return _sha1.IsNullOrEmpty() ? null : Style.ByteArrayToString(_sha1); }
 			set { _sha1 = Style.StringToByteArray(value); }
 		}
 		public string SHA256
 		{
-			get { return Style.ByteArrayToString(_sha256); }
+			get { return _sha256.IsNullOrEmpty() ? null : Style.ByteArrayToString(_sha256); }
 			set { _sha256 = Style.StringToByteArray(value); }
 		}
 		public string SHA384
 		{
-			get { return Style.ByteArrayToString(_sha384); }
+			get { return _sha384.IsNullOrEmpty() ? null : Style.ByteArrayToString(_sha384); }
 			set { _sha384 = Style.StringToByteArray(value); }
 		}
 		public string SHA512
 		{
-			get { return Style.ByteArrayToString(_sha512); }
+			get { return _sha512.IsNullOrEmpty() ? null : Style.ByteArrayToString(_sha512); }
 			set { _sha512 = Style.StringToByteArray(value); }
 		}
 		public ItemStatus ItemStatus
@@ -146,19 +146,19 @@ namespace SabreTools.Library.Items
 			}
 
 			// If we can determine that the disks have no non-empty hashes in common, we return false
-			if ((this._md5 == null || newOther._md5 == null)
-				&& (this._sha1 == null || newOther._sha1 == null)
-				&& (this._sha256 == null || newOther._sha256 == null)
-				&& (this._sha384 == null || newOther._sha384 == null)
-				&& (this._sha512 == null || newOther._sha512 == null))
+			if ((this._md5.IsNullOrEmpty() || newOther._md5.IsNullOrEmpty())
+				&& (this._sha1.IsNullOrEmpty() || newOther._sha1.IsNullOrEmpty())
+				&& (this._sha256.IsNullOrEmpty() || newOther._sha256.IsNullOrEmpty())
+				&& (this._sha384.IsNullOrEmpty() || newOther._sha384.IsNullOrEmpty())
+				&& (this._sha512.IsNullOrEmpty() || newOther._sha512.IsNullOrEmpty()))
 			{
 				dupefound = false;
 			}
-			else if (((this._md5 == null || newOther._md5 == null) || Enumerable.SequenceEqual(this._md5, newOther._md5))
-				&& ((this._sha1 == null || newOther._sha1 == null) || Enumerable.SequenceEqual(this._sha1, newOther._sha1))
-				&& ((this._sha256 == null || newOther._sha256 == null) || Enumerable.SequenceEqual(this._sha256, newOther._sha256))
-				&& ((this._sha384 == null || newOther._sha384 == null) || Enumerable.SequenceEqual(this._sha384, newOther._sha384))
-				&& ((this._sha512 == null || newOther._sha512 == null) || Enumerable.SequenceEqual(this._sha512, newOther._sha512)))
+			else if (((this._md5.IsNullOrEmpty() || newOther._md5.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._md5, newOther._md5))
+				&& ((this._sha1.IsNullOrEmpty() || newOther._sha1.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._sha1, newOther._sha1))
+				&& ((this._sha256.IsNullOrEmpty() || newOther._sha256.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._sha256, newOther._sha256))
+				&& ((this._sha384.IsNullOrEmpty() || newOther._sha384.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._sha384, newOther._sha384))
+				&& ((this._sha512.IsNullOrEmpty() || newOther._sha512.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._sha512, newOther._sha512)))
 			{
 				dupefound = true;
 			}

--- a/SabreTools.Library/Items/Disk.cs
+++ b/SabreTools.Library/Items/Disk.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 
 using SabreTools.Library.Data;
 using SabreTools.Library.Tools;

--- a/SabreTools.Library/Items/Disk.cs
+++ b/SabreTools.Library/Items/Disk.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 
 using SabreTools.Library.Data;
+using SabreTools.Library.Tools;
 
 namespace SabreTools.Library.Items
 {
@@ -12,12 +14,12 @@ namespace SabreTools.Library.Items
 		#region Private instance variables
 
 		// Disk information
-		protected string _md5;
-		protected string _sha1;
-		protected string _sha256;
-		protected string _sha384;
-		protected string _sha512;
-		protected ItemStatus _itemStatus;
+		private byte[] _md5; // 16 bytes
+		private byte[] _sha1; // 20 bytes
+		private byte[] _sha256; // 32 bytes
+		private byte[] _sha384; // 48 bytes
+		private byte[] _sha512; // 64 bytes
+		private ItemStatus _itemStatus;
 
 		#endregion
 
@@ -26,28 +28,28 @@ namespace SabreTools.Library.Items
 		// Disk information
 		public string MD5
 		{
-			get { return _md5; }
-			set { _md5 = value; }
+			get { return Style.ByteArrayToString(_md5); }
+			set { _md5 = Style.StringToByteArray(value); }
 		}
 		public string SHA1
 		{
-			get { return _sha1; }
-			set { _sha1 = value; }
+			get { return Style.ByteArrayToString(_sha1); }
+			set { _sha1 = Style.StringToByteArray(value); }
 		}
 		public string SHA256
 		{
-			get { return _sha256; }
-			set { _sha256 = value; }
+			get { return Style.ByteArrayToString(_sha256); }
+			set { _sha256 = Style.StringToByteArray(value); }
 		}
 		public string SHA384
 		{
-			get { return _sha384; }
-			set { _sha384 = value; }
+			get { return Style.ByteArrayToString(_sha384); }
+			set { _sha384 = Style.StringToByteArray(value); }
 		}
 		public string SHA512
 		{
-			get { return _sha512; }
-			set { _sha512 = value; }
+			get { return Style.ByteArrayToString(_sha512); }
+			set { _sha512 = Style.StringToByteArray(value); }
 		}
 		public ItemStatus ItemStatus
 		{
@@ -111,11 +113,11 @@ namespace SabreTools.Library.Items
 				SourceID = this.SourceID,
 				Source = this.Source,
 
-				MD5 = this.MD5,
-				SHA1 = this.SHA1,
-				SHA256 = this.SHA256,
-				SHA384 = this.SHA384,
-				SHA512 = this.SHA512,
+				_md5 = this._md5,
+				_sha1 = this._sha1,
+				_sha256 = this._sha256,
+				_sha384 = this._sha384,
+				_sha512 = this._sha512,
 				ItemStatus = this.ItemStatus,
 			};
 		}
@@ -144,19 +146,19 @@ namespace SabreTools.Library.Items
 			}
 
 			// If we can determine that the disks have no non-empty hashes in common, we return false
-			if ((String.IsNullOrEmpty(_md5) || String.IsNullOrEmpty(newOther.MD5))
-				&& (String.IsNullOrEmpty(_sha1) || String.IsNullOrEmpty(newOther.SHA1))
-				&& (String.IsNullOrEmpty(_sha256) || String.IsNullOrEmpty(newOther.SHA256))
-				&& (String.IsNullOrEmpty(_sha384) || String.IsNullOrEmpty(newOther.SHA384))
-				&& (String.IsNullOrEmpty(_sha512) || String.IsNullOrEmpty(newOther.SHA512)))
+			if ((this._md5 == null || newOther._md5 == null)
+				&& (this._sha1 == null || newOther._sha1 == null)
+				&& (this._sha256 == null || newOther._sha256 == null)
+				&& (this._sha384 == null || newOther._sha384 == null)
+				&& (this._sha512 == null || newOther._sha512 == null))
 			{
 				dupefound = false;
 			}
-			else if (((String.IsNullOrEmpty(_md5) || String.IsNullOrEmpty(newOther.MD5)) || this.MD5 == newOther.MD5)
-				&& ((String.IsNullOrEmpty(this.SHA1) || String.IsNullOrEmpty(newOther.SHA1)) || this.SHA1 == newOther.SHA1)
-				&& ((String.IsNullOrEmpty(this.SHA256) || String.IsNullOrEmpty(newOther.SHA256)) || this.SHA256 == newOther.SHA256)
-				&& ((String.IsNullOrEmpty(this.SHA384) || String.IsNullOrEmpty(newOther.SHA384)) || this.SHA384 == newOther.SHA384)
-				&& ((String.IsNullOrEmpty(this.SHA512) || String.IsNullOrEmpty(newOther.SHA512)) || this.SHA256 == newOther.SHA512))
+			else if (((this._md5 == null || newOther._md5 == null) || Enumerable.SequenceEqual(this._md5, newOther._md5))
+				&& ((this._sha1 == null || newOther._sha1 == null) || Enumerable.SequenceEqual(this._sha1, newOther._sha1))
+				&& ((this._sha256 == null || newOther._sha256 == null) || Enumerable.SequenceEqual(this._sha256, newOther._sha256))
+				&& ((this._sha384 == null || newOther._sha384 == null) || Enumerable.SequenceEqual(this._sha384, newOther._sha384))
+				&& ((this._sha512 == null || newOther._sha512 == null) || Enumerable.SequenceEqual(this._sha512, newOther._sha512)))
 			{
 				dupefound = true;
 			}

--- a/SabreTools.Library/Items/Rom.cs
+++ b/SabreTools.Library/Items/Rom.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 
 using SabreTools.Library.Data;
 using SabreTools.Library.Tools;

--- a/SabreTools.Library/Items/Rom.cs
+++ b/SabreTools.Library/Items/Rom.cs
@@ -36,32 +36,32 @@ namespace SabreTools.Library.Items
 		}
 		public string CRC
 		{
-			get { return Style.ByteArrayToString(_crc); }
+			get { return _crc.IsNullOrEmpty() ? null : Style.ByteArrayToString(_crc); }
 			set { _crc = Style.StringToByteArray(value); }
 		}
 		public string MD5
 		{
-			get { return Style.ByteArrayToString(_md5); }
+			get { return _md5.IsNullOrEmpty() ? null : Style.ByteArrayToString(_md5); }
 			set { _md5 = Style.StringToByteArray(value); }
 		}
 		public string SHA1
 		{
-			get { return Style.ByteArrayToString(_sha1); }
+			get { return _sha1.IsNullOrEmpty() ? null : Style.ByteArrayToString(_sha1); }
 			set { _sha1 = Style.StringToByteArray(value); }
 		}
 		public string SHA256
 		{
-			get { return Style.ByteArrayToString(_sha256); }
+			get { return _sha256.IsNullOrEmpty() ? null : Style.ByteArrayToString(_sha256); }
 			set { _sha256 = Style.StringToByteArray(value); }
 		}
 		public string SHA384
 		{
-			get { return Style.ByteArrayToString(_sha384); }
+			get { return _sha384.IsNullOrEmpty() ? null : Style.ByteArrayToString(_sha384); }
 			set { _sha384 = Style.StringToByteArray(value); }
 		}
 		public string SHA512
 		{
-			get { return Style.ByteArrayToString(_sha512); }
+			get { return _sha512.IsNullOrEmpty() ? null : Style.ByteArrayToString(_sha512); }
 			set { _sha512 = Style.StringToByteArray(value); }
 		}
 		public string Date
@@ -213,22 +213,22 @@ namespace SabreTools.Library.Items
 			}
 
 			// If we can determine that the roms have no non-empty hashes in common, we return false
-			if ((_crc == null || newOther._crc == null)
-				&& (this._md5 == null || newOther._md5 == null)
-				&& (this._sha1 == null || newOther._sha1 == null)
-				&& (this._sha256 == null || newOther._sha256 == null)
-				&& (this._sha384 == null || newOther._sha384 == null)
-				&& (this._sha512 == null || newOther._sha512 == null))
+			if ((_crc.IsNullOrEmpty() || newOther._crc.IsNullOrEmpty())
+				&& (this._md5.IsNullOrEmpty() || newOther._md5.IsNullOrEmpty())
+				&& (this._sha1.IsNullOrEmpty() || newOther._sha1.IsNullOrEmpty())
+				&& (this._sha256.IsNullOrEmpty() || newOther._sha256.IsNullOrEmpty())
+				&& (this._sha384.IsNullOrEmpty() || newOther._sha384.IsNullOrEmpty())
+				&& (this._sha512.IsNullOrEmpty() || newOther._sha512.IsNullOrEmpty()))
 			{
 				dupefound = false;
 			}
 			else if ((this.Size == newOther.Size)
-				&& ((this._crc == null || newOther._crc == null) || Enumerable.SequenceEqual(this._crc, newOther._crc))
-				&& ((this._md5 == null || newOther._md5 == null) || Enumerable.SequenceEqual(this._md5, newOther._md5))
-				&& ((this._sha1 == null || newOther._sha1 == null) || Enumerable.SequenceEqual(this._sha1, newOther._sha1))
-				&& ((this._sha256 == null || newOther._sha256 == null) || Enumerable.SequenceEqual(this._sha256, newOther._sha256))
-				&& ((this._sha384 == null || newOther._sha384 == null) || Enumerable.SequenceEqual(this._sha384, newOther._sha384))
-				&& ((this._sha512 == null || newOther._sha512 == null) || Enumerable.SequenceEqual(this._sha512, newOther._sha512)))
+				&& ((this._crc.IsNullOrEmpty() || newOther._crc.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._crc, newOther._crc))
+				&& ((this._md5.IsNullOrEmpty() || newOther._md5.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._md5, newOther._md5))
+				&& ((this._sha1.IsNullOrEmpty() || newOther._sha1.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._sha1, newOther._sha1))
+				&& ((this._sha256.IsNullOrEmpty() || newOther._sha256.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._sha256, newOther._sha256))
+				&& ((this._sha384.IsNullOrEmpty() || newOther._sha384.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._sha384, newOther._sha384))
+				&& ((this._sha512.IsNullOrEmpty() || newOther._sha512.IsNullOrEmpty()) || Enumerable.SequenceEqual(this._sha512, newOther._sha512)))
 			{
 				dupefound = true;
 			}

--- a/SabreTools.Library/Items/Rom.cs
+++ b/SabreTools.Library/Items/Rom.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 
 using SabreTools.Library.Data;
+using SabreTools.Library.Tools;
 
 namespace SabreTools.Library.Items
 {
@@ -13,12 +15,12 @@ namespace SabreTools.Library.Items
 
 		// Rom information
 		private long _size;
-		private string _crc;
-		private string _md5;
-		private string _sha1;
-		private string _sha256;
-		private string _sha384;
-		private string _sha512;
+		private byte[] _crc; // 8 bytes
+		private byte[] _md5; // 16 bytes
+		private byte[] _sha1; // 20 bytes
+		private byte[] _sha256; // 32 bytes
+		private byte[] _sha384; // 48 bytes
+		private byte[] _sha512; // 64 bytes
 		private string _date;
 		private ItemStatus _itemStatus;
 
@@ -34,33 +36,33 @@ namespace SabreTools.Library.Items
 		}
 		public string CRC
 		{
-			get { return _crc; }
-			set { _crc = value; }
+			get { return Style.ByteArrayToString(_crc); }
+			set { _crc = Style.StringToByteArray(value); }
 		}
 		public string MD5
 		{
-			get { return _md5; }
-			set { _md5 = value; }
+			get { return Style.ByteArrayToString(_md5); }
+			set { _md5 = Style.StringToByteArray(value); }
 		}
 		public string SHA1
 		{
-			get { return _sha1; }
-			set { _sha1 = value; }
+			get { return Style.ByteArrayToString(_sha1); }
+			set { _sha1 = Style.StringToByteArray(value); }
 		}
 		public string SHA256
 		{
-			get { return _sha256; }
-			set { _sha256 = value; }
+			get { return Style.ByteArrayToString(_sha256); }
+			set { _sha256 = Style.StringToByteArray(value); }
 		}
 		public string SHA384
 		{
-			get { return _sha384; }
-			set { _sha384 = value; }
+			get { return Style.ByteArrayToString(_sha384); }
+			set { _sha384 = Style.StringToByteArray(value); }
 		}
 		public string SHA512
 		{
-			get { return _sha512; }
-			set { _sha512 = value; }
+			get { return Style.ByteArrayToString(_sha512); }
+			set { _sha512 = Style.StringToByteArray(value); }
 		}
 		public string Date
 		{
@@ -103,27 +105,27 @@ namespace SabreTools.Library.Items
 			_size = -1;
 			if ((omitFromScan & Hash.CRC) == 0)
 			{
-				_crc = "null";
+				_crc = null;
 			}
 			if ((omitFromScan & Hash.MD5) == 0)
 			{
-				_md5 = "null";
+				_md5 = null;
 			}
 			if ((omitFromScan & Hash.SHA1) == 0)
 			{
-				_sha1 = "null";
+				_sha1 = null;
 			}
 			if ((omitFromScan & Hash.SHA256) == 0)
 			{
-				_sha256 = "null";
+				_sha256 = null;
 			}
 			if ((omitFromScan & Hash.SHA384) == 0)
 			{
-				_sha384 = "null";
+				_sha384 = null;
 			}
 			if ((omitFromScan & Hash.SHA512) == 0)
 			{
-				_sha512 = "null";
+				_sha512 = null;
 			}
 			_itemStatus = ItemStatus.None;
 
@@ -176,12 +178,12 @@ namespace SabreTools.Library.Items
 				Source = this.Source,
 
 				Size = this.Size,
-				CRC = this.CRC,
-				MD5 = this.MD5,
-				SHA1 = this.SHA1,
-				SHA256 = this.SHA256,
-				SHA384 = this.SHA384,
-				SHA512 = this.SHA512,
+				_crc = this._crc,
+				_md5 = this._md5,
+				_sha1 = this._sha1,
+				_sha256 = this._sha256,
+				_sha384 = this._sha384,
+				_sha512 = this._sha512,
 				ItemStatus = this.ItemStatus,
 				Date = this.Date,
 			};
@@ -211,22 +213,22 @@ namespace SabreTools.Library.Items
 			}
 
 			// If we can determine that the roms have no non-empty hashes in common, we return false
-			if ((String.IsNullOrEmpty(_crc) || String.IsNullOrEmpty(newOther.CRC))
-				&& (String.IsNullOrEmpty(_md5) || String.IsNullOrEmpty(newOther.MD5))
-				&& (String.IsNullOrEmpty(_sha1) || String.IsNullOrEmpty(newOther.SHA1))
-				&& (String.IsNullOrEmpty(_sha256) || String.IsNullOrEmpty(newOther.SHA256))
-				&& (String.IsNullOrEmpty(_sha384) || String.IsNullOrEmpty(newOther.SHA384))
-				&& (String.IsNullOrEmpty(_sha512) || String.IsNullOrEmpty(newOther.SHA512)))
+			if ((_crc == null || newOther._crc == null)
+				&& (this._md5 == null || newOther._md5 == null)
+				&& (this._sha1 == null || newOther._sha1 == null)
+				&& (this._sha256 == null || newOther._sha256 == null)
+				&& (this._sha384 == null || newOther._sha384 == null)
+				&& (this._sha512 == null || newOther._sha512 == null))
 			{
 				dupefound = false;
 			}
 			else if ((this.Size == newOther.Size)
-				&& ((String.IsNullOrEmpty(_crc) || String.IsNullOrEmpty(newOther.CRC)) || _crc == newOther.CRC)
-				&& ((String.IsNullOrEmpty(_md5) || String.IsNullOrEmpty(newOther.MD5)) || _md5 == newOther.MD5)
-				&& ((String.IsNullOrEmpty(_sha1) || String.IsNullOrEmpty(newOther.SHA1)) || _sha1 == newOther.SHA1)
-				&& ((String.IsNullOrEmpty(_sha256) || String.IsNullOrEmpty(newOther.SHA256)) || _sha256 == newOther.SHA256)
-				&& ((String.IsNullOrEmpty(_sha384) || String.IsNullOrEmpty(newOther.SHA384)) || _sha384 == newOther.SHA384)
-				&& ((String.IsNullOrEmpty(_sha512) || String.IsNullOrEmpty(newOther.SHA512)) || _sha512 == newOther.SHA512))
+				&& ((this._crc == null || newOther._crc == null) || Enumerable.SequenceEqual(this._crc, newOther._crc))
+				&& ((this._md5 == null || newOther._md5 == null) || Enumerable.SequenceEqual(this._md5, newOther._md5))
+				&& ((this._sha1 == null || newOther._sha1 == null) || Enumerable.SequenceEqual(this._sha1, newOther._sha1))
+				&& ((this._sha256 == null || newOther._sha256 == null) || Enumerable.SequenceEqual(this._sha256, newOther._sha256))
+				&& ((this._sha384 == null || newOther._sha384 == null) || Enumerable.SequenceEqual(this._sha384, newOther._sha384))
+				&& ((this._sha512 == null || newOther._sha512 == null) || Enumerable.SequenceEqual(this._sha512, newOther._sha512)))
 			{
 				dupefound = true;
 			}

--- a/SabreTools.Library/Tools/FileTools.cs
+++ b/SabreTools.Library/Tools/FileTools.cs
@@ -720,10 +720,7 @@ namespace SabreTools.Library.Tools
 
 			// Extract the header as a string for the database
 			byte[] hbin = br.ReadBytes((int)rule.StartOffset);
-			for (int i = 0; i < (int)rule.StartOffset; i++)
-			{
-				hstr += BitConverter.ToString(new byte[] { hbin[i] });
-			}
+			hstr = Style.ByteArrayToString(hbin);
 			br.Dispose();
 
 			// Apply the rule to the file
@@ -1199,27 +1196,27 @@ namespace SabreTools.Library.Tools
 				if ((omitFromScan & Hash.MD5) == 0)
 				{
 					md5.TransformFinalBlock(buffer, 0, 0);
-					rom.MD5 = BitConverter.ToString(md5.Hash).Replace("-", "").ToLowerInvariant();
+					rom.MD5 = Style.ByteArrayToString(md5.Hash);
 				}
 				if ((omitFromScan & Hash.SHA1) == 0)
 				{
 					sha1.TransformFinalBlock(buffer, 0, 0);
-					rom.SHA1 = BitConverter.ToString(sha1.Hash).Replace("-", "").ToLowerInvariant();
+					rom.SHA1 = Style.ByteArrayToString(sha1.Hash);
 				}
 				if ((omitFromScan & Hash.SHA256) == 0)
 				{
 					sha256.TransformFinalBlock(buffer, 0, 0);
-					rom.SHA256 = BitConverter.ToString(sha256.Hash).Replace("-", "").ToLowerInvariant();
+					rom.SHA256 = Style.ByteArrayToString(sha256.Hash);
 				}
 				if ((omitFromScan & Hash.SHA384) == 0)
 				{
 					sha384.TransformFinalBlock(buffer, 0, 0);
-					rom.SHA384 = BitConverter.ToString(sha384.Hash).Replace("-", "").ToLowerInvariant();
+					rom.SHA384 = Style.ByteArrayToString(sha384.Hash);
 				}
 				if ((omitFromScan & Hash.SHA512) == 0)
 				{
 					sha512.TransformFinalBlock(buffer, 0, 0);
-					rom.SHA512 = BitConverter.ToString(sha512.Hash).Replace("-", "").ToLowerInvariant();
+					rom.SHA512 = Style.ByteArrayToString(sha512.Hash);
 				}
 				if ((omitFromScan & Hash.xxHash) == 0)
 				{
@@ -1283,7 +1280,7 @@ namespace SabreTools.Library.Tools
 			byte[] sha1 = chd.GetSHA1FromHeader();
 
 			// Set the SHA-1 of the Disk to return
-			datItem.SHA1 = (sha1 == null ? null : BitConverter.ToString(sha1).Replace("-", string.Empty).ToLowerInvariant());
+			datItem.SHA1 = (sha1 == null ? null : Style.ByteArrayToString(sha1));
 
 			return datItem;
 		}

--- a/SabreTools.Library/Tools/Style.cs
+++ b/SabreTools.Library/Tools/Style.cs
@@ -938,13 +938,36 @@ namespace SabreTools.Library.Tools
 		/// <summary>
 		/// http://stackoverflow.com/questions/311165/how-do-you-convert-byte-array-to-hexadecimal-string-and-vice-versa
 		/// </summary>
+		public static string ByteArrayToString(byte[] bytes)
+		{
+			try
+			{
+				string hex = BitConverter.ToString(bytes);
+				return hex.Replace("-", string.Empty).ToLowerInvariant();
+			}
+			catch
+			{
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// http://stackoverflow.com/questions/311165/how-do-you-convert-byte-array-to-hexadecimal-string-and-vice-versa
+		/// </summary>
 		public static byte[] StringToByteArray(string hex)
 		{
-			int NumberChars = hex.Length;
-			byte[] bytes = new byte[NumberChars / 2];
-			for (int i = 0; i < NumberChars; i += 2)
-				bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
-			return bytes;
+			try
+			{
+				int NumberChars = hex.Length;
+				byte[] bytes = new byte[NumberChars / 2];
+				for (int i = 0; i < NumberChars; i += 2)
+					bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+				return bytes;
+			}
+			catch
+			{
+				return null;
+			}
 		}
 
 		/// <summary>

--- a/SabreTools.Library/Tools/Style.cs
+++ b/SabreTools.Library/Tools/Style.cs
@@ -14,6 +14,7 @@ using System.IO;
 #else
 using Alphaleonis.Win32.Filesystem;
 
+using BinaryReader = System.IO.BinaryReader;
 using FileStream = System.IO.FileStream;
 #endif
 
@@ -395,6 +396,162 @@ namespace SabreTools.Library.Tools
 			}
 
 			return outfile;
+		}
+
+		#endregion
+
+		#region Extensions
+
+		/// <summary>
+		/// Reads the specified number of bytes from the stream, starting from a specified point in the byte array.
+		/// </summary>
+		/// <param name="buffer">The buffer to read data into.</param>
+		/// <param name="index">The starting point in the buffer at which to begin reading into the buffer.</param>
+		/// <param name="count">The number of bytes to read.</param>
+		/// <returns>The number of bytes read into buffer. This might be less than the number of bytes requested if that many bytes are not available, or it might be zero if the end of the stream is reached.</returns>
+		public static int ReadReverse(this BinaryReader reader, byte[] buffer, int index, int count)
+		{
+			int retval = reader.Read(buffer, index, count);
+			buffer = buffer.Reverse().ToArray();
+			return retval;
+		}
+
+		/// <summary>
+		/// Reads the specified number of characters from the stream, starting from a specified point in the character array.
+		/// </summary>
+		/// <param name="buffer">The buffer to read data into.</param>
+		/// <param name="index">The starting point in the buffer at which to begin reading into the buffer.</param>
+		/// <param name="count">The number of characters to read.</param>
+		/// <returns>The total number of characters read into the buffer. This might be less than the number of characters requested if that many characters are not currently available, or it might be zero if the end of the stream is reached.</returns>
+		public static int ReadReverse(this BinaryReader reader, char[] buffer, int index, int count)
+
+		{
+			int retval = reader.Read(buffer, index, count);
+			buffer = buffer.Reverse().ToArray();
+			return retval;
+		}
+
+		/// <summary>
+		/// Reads the specified number of bytes from the current stream into a byte array and advances the current position by that number of bytes.
+		/// </summary>
+		/// <param name="count">The number of bytes to read. This value must be 0 or a non-negative number or an exception will occur.</param>
+		/// <returns>A byte array containing data read from the underlying stream. This might be less than the number of bytes requested if the end of the stream is reached.</returns>
+		public static byte[] ReadBytesReverse(this BinaryReader reader, int count)
+		{
+			byte[] retval = reader.ReadBytes(count);
+			retval = retval.Reverse().ToArray();
+			return retval;
+		}
+
+		/// <summary>
+		/// Reads a decimal value from the current stream and advances the current position of the stream by sixteen bytes.
+		/// </summary>
+		/// <returns>A decimal value read from the current stream.</returns>
+		public static decimal ReadDecimalReverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(16);
+			retval = retval.Reverse().ToArray();
+
+			int i1 = BitConverter.ToInt32(retval, 0);
+			int i2 = BitConverter.ToInt32(retval, 4);
+			int i3 = BitConverter.ToInt32(retval, 8);
+			int i4 = BitConverter.ToInt32(retval, 12);
+
+			return new decimal(new int[] { i1, i2, i3, i4 });
+		}
+
+		/// <summary>
+		/// eads an 8-byte floating point value from the current stream and advances the current position of the stream by eight bytes.
+		/// </summary>
+		/// <returns>An 8-byte floating point value read from the current stream.</returns>
+		public static double ReadDoubleReverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(8);
+			retval = retval.Reverse().ToArray();
+			return BitConverter.ToDouble(retval, 0);
+		}
+
+		/// <summary>
+		/// Reads a 2-byte signed integer from the current stream and advances the current position of the stream by two bytes.
+		/// </summary>
+		/// <returns>A 2-byte signed integer read from the current stream.</returns>
+		public static short ReadInt16Reverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(2);
+			retval = retval.Reverse().ToArray();
+			return BitConverter.ToInt16(retval, 0);
+		}
+
+		/// <summary>
+		/// Reads a 4-byte signed integer from the current stream and advances the current position of the stream by four bytes.
+		/// </summary>
+		/// <returns>A 4-byte signed integer read from the current stream.</returns>
+		public static int ReadInt32Reverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(4);
+			retval = retval.Reverse().ToArray();
+			return BitConverter.ToInt32(retval, 0);
+		}
+
+		/// <summary>
+		/// Reads an 8-byte signed integer from the current stream and advances the current position of the stream by eight bytes.
+		/// </summary>
+		/// <returns>An 8-byte signed integer read from the current stream.</returns>
+		public static long ReadInt64Reverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(8);
+			retval = retval.Reverse().ToArray();
+			return BitConverter.ToInt64(retval, 0);
+		}
+
+		/// <summary>
+		/// Reads a 4-byte floating point value from the current stream and advances the current position of the stream by four bytes.
+		/// </summary>
+		/// <returns>A 4-byte floating point value read from the current stream.</returns>
+		public static float ReadSingleReverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(4);
+			retval = retval.Reverse().ToArray();
+			return BitConverter.ToSingle(retval, 0);
+		}
+
+		/// <summary>
+		/// Reads a 2-byte unsigned integer from the current stream using little-endian encoding and advances the position of the stream by two bytes.
+		/// 
+		/// This API is not CLS-compliant.
+		/// </summary>
+		/// <returns>A 2-byte unsigned integer read from this stream.</returns>
+		public static ushort ReadUInt16Reverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(2);
+			retval = retval.Reverse().ToArray();
+			return BitConverter.ToUInt16(retval, 0);
+		}
+
+		/// <summary>
+		/// Reads a 4-byte unsigned integer from the current stream and advances the position of the stream by four bytes.
+		/// 
+		/// This API is not CLS-compliant.
+		/// </summary>
+		/// <returns>A 4-byte unsigned integer read from this stream.</returns>
+		public static uint ReadUInt32Reverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(4);
+			retval = retval.Reverse().ToArray();
+			return BitConverter.ToUInt32(retval, 0);
+		}
+
+		/// <summary>
+		/// Reads an 8-byte unsigned integer from the current stream and advances the position of the stream by eight bytes.
+		/// 
+		/// This API is not CLS-compliant.
+		/// </summary>
+		/// <returns>An 8-byte unsigned integer read from this stream.</returns>
+		public static ulong ReadUInt64Reverse(this BinaryReader reader)
+		{
+			byte[] retval = reader.ReadBytes(8);
+			retval = retval.Reverse().ToArray();
+			return BitConverter.ToUInt64(retval, 0);
 		}
 
 		#endregion

--- a/SabreTools.Library/Tools/Style.cs
+++ b/SabreTools.Library/Tools/Style.cs
@@ -1084,6 +1084,17 @@ namespace SabreTools.Library.Tools
 			return localTime;
 		}
 
+		/// <summary>
+		/// Indicates whether the specified array is null or has a length of zero.
+		/// https://stackoverflow.com/questions/8560106/isnullorempty-equivalent-for-array-c-sharp
+		/// </summary>
+		/// <param name="array">The array to test.</param>
+		/// <returns>true if the array parameter is null or has a length of zero; otherwise, false.</returns>
+		public static bool IsNullOrEmpty(this Array array)
+		{
+			return (array == null || array.Length == 0);
+		}
+
 		#endregion
 	}
 }

--- a/SabreTools/SabreTools.Inits.cs
+++ b/SabreTools/SabreTools.Inits.cs
@@ -338,7 +338,7 @@ namespace SabreTools
 			SplitType splitType, bool chdsAsFiles)
 		{
 			// Get the archive scanning level
-			ArchiveScanLevel asl = ArchiveTools.GetArchiveScanLevelFromNumbers(sevenzip, gz, rar, zip);
+			ArchiveScanLevel asl = FileTools.GetArchiveScanLevelFromNumbers(sevenzip, gz, rar, zip);
 
 			// Get a list of files from the input datfiles
 			datfiles = FileTools.GetOnlyFilesFromInputs(datfiles);
@@ -749,7 +749,7 @@ namespace SabreTools
 			string headerToCheckAgainst, SplitType splitType, bool chdsAsFiles)
 		{
 			// Get the archive scanning level
-			ArchiveScanLevel asl = ArchiveTools.GetArchiveScanLevelFromNumbers(1, 1, 1, 1);
+			ArchiveScanLevel asl = FileTools.GetArchiveScanLevelFromNumbers(1, 1, 1, 1);
 
 			// Get a list of files from the input datfiles
 			datfiles = FileTools.GetOnlyFilesFromInputs(datfiles);


### PR DESCRIPTION
Use ByteArrays for hashes instead of storing them as strings. This should reduce the memory footprint of most major operations by at least 50%