### PR TITLE
Filter Abstraction

### DIFF
--- a/SabreTools.Library/DatFiles/ClrMamePro.cs
+++ b/SabreTools.Library/DatFiles/ClrMamePro.cs
@@ -241,6 +241,9 @@ namespace SabreTools.Library.DatFiles
                         case "manufacturer":
                             machine.Manufacturer = itemVal;
                             break;
+                        case "category":
+                            machine.Category = itemVal;
+                            break;
                         case "cloneof":
                             machine.CloneOf = itemVal;
                             break;
@@ -634,6 +637,8 @@ namespace SabreTools.Library.DatFiles
                     cmpw.WriteStandalone("year", datItem.Year);
                 if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Manufacturer, DatHeader.ExcludeFields)))
                     cmpw.WriteStandalone("manufacturer", datItem.Manufacturer);
+                if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Category, DatHeader.ExcludeFields)))
+                    cmpw.WriteStandalone("category", datItem.Category);
 
                 cmpw.Flush();
             }

--- a/SabreTools.Library/DatFiles/DatFile.cs
+++ b/SabreTools.Library/DatFiles/DatFile.cs
@@ -1147,6 +1147,9 @@ namespace SabreTools.Library.DatFiles
                                 if (updateFields.Contains(Field.Publisher))
                                     newDatItem.Publisher = firstDupe.Publisher;
 
+                                if (updateFields.Contains(Field.Category))
+                                    newDatItem.Category = firstDupe.Category;
+
                                 if (updateFields.Contains(Field.RomOf))
                                     newDatItem.RomOf = firstDupe.RomOf;
 
@@ -3659,6 +3662,7 @@ namespace SabreTools.Library.DatFiles
                 name = item.Name,
                 manufacturer = item.Manufacturer,
                 publisher = item.Publisher,
+                category = item.Category,
                 crc = string.Empty,
                 md5 = string.Empty,
                 ripemd160 = string.Empty,
@@ -3709,6 +3713,7 @@ namespace SabreTools.Library.DatFiles
                 .Replace("%name%", name)
                 .Replace("%manufacturer%", manufacturer)
                 .Replace("%publisher%", publisher)
+                .Replace("%category%", category)
                 .Replace("%crc%", crc)
                 .Replace("%md5%", md5)
                 .Replace("%ripemd160%", ripemd160)

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -19,455 +19,231 @@ namespace SabreTools.Library.DatFiles
     {
         #region Private instance variables
 
-        private Dictionary<string, object> Filters { get; set; } = new Dictionary<string, object>()
-        {
-            #region Machine Filters
-
-            { "Machine.Name", new FilterItem<string>() },
-            { "Machine.Comment", new FilterItem<string>() },
-            { "Machine.Description", new FilterItem<string>() },
-            { "Machine.Year", new FilterItem<string>() },
-            { "Machine.Manufacturer", new FilterItem<string>() },
-            { "Machine.Publisher", new FilterItem<string>() },
-            { "Machine.Category", new FilterItem<string>() },
-            { "Machine.RomOf", new FilterItem<string>() },
-            { "Machine.CloneOf", new FilterItem<string>() },
-            { "Machine.SampleOf", new FilterItem<string>() },
-            { "Machine.Supported", new FilterItem<bool?>() { Neutral = null } },
-            { "Machine.SourceFile", new FilterItem<string>() },
-            { "Machine.Runnable", new FilterItem<bool?>() { Neutral = null } },
-            { "Machine.Board", new FilterItem<string>() },
-            { "Machine.RebuildTo", new FilterItem<string>() },
-            { "Machine.Devices", new FilterItem<string>() }, // TODO: List<string>
-            { "Machine.SlotOptions", new FilterItem<string>() }, // TODO: List<string>
-            { "Machine.Infos", new FilterItem<string>() }, // TODO: List<KeyValuePair<string, string>>
-            { "Machine.MachineType", new FilterItem<MachineType>() { Positive = MachineType.NULL, Negative = MachineType.NULL } },
-
-            #endregion
-
-            #region DatItem Filters
-
-            { "DatItem.Type", new FilterItem<string>() },
-            { "DatItem.Name", new FilterItem<string>() },
-            { "DatItem.PartName", new FilterItem<string>() },
-            { "DatItem.PartInterface", new FilterItem<string>() },
-            { "DatItem.Features", new FilterItem<string>() }, // TODO: List<KeyValuePair<string, string>>
-            { "DatItem.AreaName", new FilterItem<string>() },
-            { "DatItem.AreaSize", new FilterItem<long?>() { Positive = null, Negative = null, Neutral = null } },
-            { "DatItem.Default", new FilterItem<bool?>() { Neutral = null } },
-            { "DatItem.Description", new FilterItem<string>() },
-            { "DatItem.Size", new FilterItem<long>() { Positive = -1, Negative = -1, Neutral = -1 } },
-            { "DatItem.CRC", new FilterItem<string>() },
-            { "DatItem.MD5", new FilterItem<string>() },
-#if NET_FRAMEWORK
-            { "DatItem.RIPEMD160", new FilterItem<string>() },
-#endif
-            { "DatItem.SHA1", new FilterItem<string>() },
-            { "DatItem.SHA256", new FilterItem<string>() },
-            { "DatItem.SHA384", new FilterItem<string>() },
-            { "DatItem.SHA512", new FilterItem<string>() },
-            { "DatItem.Merge", new FilterItem<string>() },
-            { "DatItem.Region", new FilterItem<string>() },
-            { "DatItem.Index", new FilterItem<string>() },
-            { "DatItem.Writable", new FilterItem<bool?>() { Neutral = null } },
-            { "DatItem.Optional", new FilterItem<bool?>() { Neutral = null } },
-            { "DatItem.Status", new FilterItem<ItemStatus>() { Positive = ItemStatus.NULL, Negative = ItemStatus.NULL } },
-            { "DatItem.Language", new FilterItem<string>() },
-            { "DatItem.Date", new FilterItem<string>() },
-            { "DatItem.Bios", new FilterItem<string>() },
-            { "DatItem.Offset", new FilterItem<string>() },
-
-            #endregion
-        };
-
-        // TODO: Can these explicit vars be removed eventually?
         #region Machine Filters
 
         /// <summary>
         /// Include or exclude machine names
         /// </summary>
-        private FilterItem<string> MachineName
-        {
-            get { return Filters["Machine.Name"] as FilterItem<string>; }
-            set { Filters["Machine.Name"] = value; }
-        }
+        private FilterItem<string> MachineName = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine comments
         /// </summary>
-        private FilterItem<string> Comment
-        {
-            get { return Filters["Machine.Comment"] as FilterItem<string>; }
-            set { Filters["Machine.Comment"] = value; }
-        }
+        private FilterItem<string> Comment = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine descriptions
         /// </summary>
-        private FilterItem<string> MachineDescription
-        {
-            get { return Filters["Machine.Description"] as FilterItem<string>; }
-            set { Filters["Machine.Description"] = value; }
-        }
+        private FilterItem<string> MachineDescription = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine years
         /// </summary>
-        private FilterItem<string> Year
-        {
-            get { return Filters["Machine.Year"] as FilterItem<string>; }
-            set { Filters["Machine.Year"] = value; }
-        }
+        private FilterItem<string> Year = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine manufacturers
         /// </summary>
-        private FilterItem<string> Manufacturer
-        {
-            get { return Filters["Machine.Manufacturer"] as FilterItem<string>; }
-            set { Filters["Machine.Manufacturer"] = value; }
-        }
+        private FilterItem<string> Manufacturer = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine publishers
         /// </summary>
-        private FilterItem<string> Publisher
-        {
-            get { return Filters["Machine.Publisher"] as FilterItem<string>; }
-            set { Filters["Machine.Publisher"] = value; }
-        }
+        private FilterItem<string> Publisher = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine categories
         /// </summary>
-        private FilterItem<string> Category
-        {
-            get { return Filters["Machine.Category"] as FilterItem<string>; }
-            set { Filters["Machine.Category"] = value; }
-        }
+        private FilterItem<string> Category = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine romof
         /// </summary>
-        private FilterItem<string> RomOf
-        {
-            get { return Filters["Machine.RomOf"] as FilterItem<string>; }
-            set { Filters["Machine.RomOf"] = value; }
-        }
+        private FilterItem<string> RomOf = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine cloneof
         /// </summary>
-        private FilterItem<string> CloneOf
-        {
-            get { return Filters["Machine.CloneOf"] as FilterItem<string>; }
-            set { Filters["Machine.CloneOf"] = value; }
-        }
+        private FilterItem<string> CloneOf = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine sampleof
         /// </summary>
-        private FilterItem<string> SampleOf
-        {
-            get { return Filters["Machine.SampleOf"] as FilterItem<string>; }
-            set { Filters["Machine.SampleOf"] = value; }
-        }
+        private FilterItem<string> SampleOf = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude items with the "Supported" tag
         /// </summary>
-        private FilterItem<bool?> Supported
-        {
-            get { return Filters["Machine.Supported"] as FilterItem<bool?>; }
-            set { Filters["Machine.Supported"] = value; }
-        }
+        private FilterItem<bool?> Supported = new FilterItem<bool?>() { Neutral = null };
 
         /// <summary>
         /// Include or exclude machine source file
         /// </summary>
-        private FilterItem<string> SourceFile
-        {
-            get { return Filters["Machine.SourceFile"] as FilterItem<string>; }
-            set { Filters["Machine.SourceFile"] = value; }
-        }
+        private FilterItem<string> SourceFile = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude items with the "Runnable" tag
         /// </summary>
-        private FilterItem<bool?> Runnable
-        {
-            get { return Filters["Machine.Runnable"] as FilterItem<bool?>; }
-            set { Filters["Machine.Runnable"] = value; }
-        }
+        private FilterItem<bool?> Runnable = new FilterItem<bool?>() { Neutral = null };
 
         /// <summary>
         /// Include or exclude machine board
         /// </summary>
-        private FilterItem<string> Board
-        {
-            get { return Filters["Machine.Board"] as FilterItem<string>; }
-            set { Filters["Machine.Board"] = value; }
-        }
+        private FilterItem<string> Board = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude machine rebuildto
         /// </summary>
-        private FilterItem<string> RebuildTo
-        {
-            get { return Filters["Machine.RebuildTo"] as FilterItem<string>; }
-            set { Filters["Machine.RebuildTo"] = value; }
-        }
+        private FilterItem<string> RebuildTo = new FilterItem<string>();
+
+        // TODO: Machine.Devices - List<string>
+        // TODO: Machine.SlotOptions - List<string>
+        // TODO: Machine.Infos - List<KeyValuePair<string, string>>
 
         /// <summary>
         /// Include or exclude machine types
         /// </summary>
-        private FilterItem<MachineType> MachineTypes
-        {
-            get { return Filters["Machine.MachineType"] as FilterItem<MachineType>; }
-            set { Filters["Machine.MachineType"] = value; }
-        }
+        private FilterItem<MachineType> MachineTypes = new FilterItem<MachineType>() { Positive = MachineType.NULL, Negative = MachineType.NULL };
 
         #endregion
 
-        // TODO: Can these explicit vars be removed eventually?
         #region DatItem Filters
 
         /// <summary>
         /// Include or exclude item types
         /// </summary>
-        private FilterItem<string> ItemTypes
-        {
-            get { return Filters["DatItem.Type"] as FilterItem<string>; }
-            set { Filters["DatItem.Type"] = value; }
-        }
+        private FilterItem<string> ItemTypes = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude item names
         /// </summary>
-        private FilterItem<string> ItemName
-        {
-            get { return Filters["DatItem.Name"] as FilterItem<string>; }
-            set { Filters["DatItem.Name"] = value; }
-        }
+        private FilterItem<string> ItemName = new FilterItem<string>();
+
+        // TODO: DatItem.Features - List<KeyValuePair<string, string>>
 
         /// <summary>
         /// Include or exclude part names
         /// </summary>
-        private FilterItem<string> PartName
-        {
-            get { return Filters["DatItem.PartName"] as FilterItem<string>; }
-            set { Filters["DatItem.PartName"] = value; }
-        }
+        private FilterItem<string> PartName = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude part interfaces
         /// </summary>
-        private FilterItem<string> PartInterface
-        {
-            get { return Filters["DatItem.PartInterface"] as FilterItem<string>; }
-            set { Filters["DatItem.PartInterface"] = value; }
-        }
+        private FilterItem<string> PartInterface = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude area names
         /// </summary>
-        private FilterItem<string> AreaName
-        {
-            get { return Filters["DatItem.AreaName"] as FilterItem<string>; }
-            set { Filters["DatItem.AreaName"] = value; }
-        }
+        private FilterItem<string> AreaName = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude area sizes
         /// </summary>
-        private FilterItem<long?> AreaSize
-        {
-            get { return Filters["DatItem.AreaSize"] as FilterItem<long?>; }
-            set { Filters["DatItem.AreaSize"] = value; }
-        }
+        /// <remarks>Positive means "Greater than or equal", Negative means "Less than or equal", Neutral means "Equal"</remarks>
+        private FilterItem<long?> AreaSize = new FilterItem<long?>() { Positive = null, Negative = null, Neutral = null };
 
         /// <summary>
         /// Include or exclude items with the "Default" tag
         /// </summary>
-        private FilterItem<bool?> Default
-        {
-            get { return Filters["DatItem.Default"] as FilterItem<bool?>; }
-            set { Filters["DatItem.Default"] = value; }
-        }
+        private FilterItem<bool?> Default = new FilterItem<bool?>() { Neutral = null };
 
         /// <summary>
         /// Include or exclude descriptions
         /// </summary>
-        private FilterItem<string> Description
-        {
-            get { return Filters["DatItem.Description"] as FilterItem<string>; }
-            set { Filters["DatItem.Description"] = value; }
-        }
+        private FilterItem<string> Description = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude item sizes
         /// </summary>
         /// <remarks>Positive means "Greater than or equal", Negative means "Less than or equal", Neutral means "Equal"</remarks>
-        private FilterItem<long> Size
-        {
-            get { return Filters["DatItem.Size"] as FilterItem<long>; }
-            set { Filters["DatItem.Size"] = value; }
-        }
+        private FilterItem<long> Size = new FilterItem<long>() { Positive = -1, Negative = -1, Neutral = -1 };
 
         /// <summary>
         /// Include or exclude CRC32 hashes
         /// </summary>
-        private FilterItem<string> CRC
-        {
-            get { return Filters["DatItem.CRC"] as FilterItem<string>; }
-            set { Filters["DatItem.CRC"] = value; }
-        }
+        private FilterItem<string> CRC = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude MD5 hashes
         /// </summary>
-        private FilterItem<string> MD5
-        {
-            get { return Filters["DatItem.MD5"] as FilterItem<string>; }
-            set { Filters["DatItem.MD5"] = value; }
-        }
+        private FilterItem<string> MD5 = new FilterItem<string>();
 
 #if NET_FRAMEWORK
         /// <summary>
         /// Include or exclude RIPEMD160 hashes
         /// </summary>
-        private FilterItem<string> RIPEMD160
-        {
-            get { return Filters["DatItem.RIPEMD160"] as FilterItem<string>; }
-            set { Filters["DatItem.RIPEMD160"] = value; }
-        }
+        private FilterItem<string> RIPEMD160 = new FilterItem<string>();
 #endif
 
         /// <summary>
         /// Include or exclude SHA-1 hashes
         /// </summary>
-        private FilterItem<string> SHA1
-        {
-            get { return Filters["DatItem.SHA1"] as FilterItem<string>; }
-            set { Filters["DatItem.SHA1"] = value; }
-        }
+        private FilterItem<string> SHA1 = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude SHA-256 hashes
         /// </summary>
-        private FilterItem<string> SHA256
-        {
-            get { return Filters["DatItem.SHA256"] as FilterItem<string>; }
-            set { Filters["DatItem.SHA256"] = value; }
-        }
+        private FilterItem<string> SHA256 = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude SHA-384 hashes
         /// </summary>
-        private FilterItem<string> SHA384
-        {
-            get { return Filters["DatItem.SHA384"] as FilterItem<string>; }
-            set { Filters["DatItem.SHA384"] = value; }
-        }
+        private FilterItem<string> SHA384 = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude SHA-512 hashes
         /// </summary>
-        private FilterItem<string> SHA512
-        {
-            get { return Filters["DatItem.SHA512"] as FilterItem<string>; }
-            set { Filters["DatItem.SHA512"] = value; }
-        }
+        private FilterItem<string> SHA512 = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude merge tags
         /// </summary>
-        private FilterItem<string> MergeTag
-        {
-            get { return Filters["DatItem.Merge"] as FilterItem<string>; }
-            set { Filters["DatItem.Merge"] = value; }
-        }
+        private FilterItem<string> MergeTag = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude regions
         /// </summary>
-        private FilterItem<string> Region
-        {
-            get { return Filters["DatItem.Region"] as FilterItem<string>; }
-            set { Filters["DatItem.Region"] = value; }
-        }
+        private FilterItem<string> Region = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude indexes
         /// </summary>
-        private FilterItem<string> Index
-        {
-            get { return Filters["DatItem.Index"] as FilterItem<string>; }
-            set { Filters["DatItem.Index"] = value; }
-        }
+        private FilterItem<string> Index = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude items with the "Writable" tag
         /// </summary>
-        private FilterItem<bool?> Writable
-        {
-            get { return Filters["DatItem.Writable"] as FilterItem<bool?>; }
-            set { Filters["DatItem.Writable"] = value; }
-        }
+        private FilterItem<bool?> Writable = new FilterItem<bool?>() { Neutral = null };
 
         /// <summary>
         /// Include or exclude items with the "Writable" tag
         /// </summary>
-        private FilterItem<bool?> Optional
-        {
-            get { return Filters["DatItem.Optional"] as FilterItem<bool?>; }
-            set { Filters["DatItem.Optional"] = value; }
-        }
+        private FilterItem<bool?> Optional = new FilterItem<bool?>() { Neutral = null };
 
         /// <summary>
         /// Include or exclude item statuses
         /// </summary>
-        private FilterItem<ItemStatus> Status
-        {
-            get { return Filters["DatItem.Status"] as FilterItem<ItemStatus>; }
-            set { Filters["DatItem.Status"] = value; }
-        }
+        private FilterItem<ItemStatus> Status = new FilterItem<ItemStatus>() { Positive = ItemStatus.NULL, Negative = ItemStatus.NULL };
 
         /// <summary>
         /// Include or exclude languages
         /// </summary>
-        private FilterItem<string> Language
-        {
-            get { return Filters["DatItem.Language"] as FilterItem<string>; }
-            set { Filters["DatItem.Language"] = value; }
-        }
+        private FilterItem<string> Language = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude dates
         /// </summary>
-        private FilterItem<string> Date
-        {
-            get { return Filters["DatItem.Date"] as FilterItem<string>; }
-            set { Filters["DatItem.Date"] = value; }
-        }
+        private FilterItem<string> Date = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude bioses
         /// </summary>
-        private FilterItem<string> Bios
-        {
-            get { return Filters["DatItem.Bios"] as FilterItem<string>; }
-            set { Filters["DatItem.Bios"] = value; }
-        }
+        private FilterItem<string> Bios = new FilterItem<string>();
 
         /// <summary>
         /// Include or exclude offsets
         /// </summary>
-        private FilterItem<string> Offset
-        {
-            get { return Filters["DatItem.Offset"] as FilterItem<string>; }
-            set { Filters["DatItem.Offset"] = value; }
-        }
+        private FilterItem<string> Offset = new FilterItem<string>();
 
         #endregion
 
@@ -535,9 +311,10 @@ namespace SabreTools.Library.DatFiles
                 bool negate = filterPairTrimmed.StartsWith("!") || filterPairTrimmed.StartsWith("~");
                 filterPairTrimmed = filterPairTrimmed.TrimStart('!', '~');
 
-                string filterField = filterPairTrimmed.Split(':')[0].ToLowerInvariant().Trim('"', ' ', '\t');
-                string filterValue = filterPairTrimmed.Substring(filterField.Length + 1).Trim('"', ' ', '\t');
+                string filterFieldString = filterPairTrimmed.Split(':')[0].ToLowerInvariant().Trim('"', ' ', '\t');
+                string filterValue = filterPairTrimmed.Substring(filterFieldString.Length + 1).Trim('"', ' ', '\t');
 
+                Field filterField = filterFieldString.AsField();
                 SetFilter(filterField, filterValue, negate);
             }
         }
@@ -548,7 +325,7 @@ namespace SabreTools.Library.DatFiles
         /// <param name="key">Key for the filter to be set</param>
         /// <param name="values">List of values for the filter</param>
         /// <param name="negate">True if negative filter, false otherwise</param>
-        public void SetFilter(string key, List<string> values, bool negate)
+        public void SetFilter(Field key, List<string> values, bool negate)
         {
             foreach (string value in values)
             {
@@ -562,143 +339,118 @@ namespace SabreTools.Library.DatFiles
         /// <param name="key">Key for the filter to be set</param>
         /// <param name="value">Value of the filter</param>
         /// <param name="negate">True if negative filter, false otherwise</param>
-        public void SetFilter(string key, string value, bool negate)
+        public void SetFilter(Field key, string value, bool negate)
         {
             switch (key)
             {
                 #region Machine Filters
 
-                // Machine.Name
-                case "game":
-                case "gamename":
-                case "machine":
-                case "machinename":
+                case Field.MachineName:
                     if (negate)
                         MachineName.NegativeSet.Add(value);
                     else
                         MachineName.PositiveSet.Add(value);
                     break;
 
-                // Machine.Comment
-                case "comment":
+                case Field.Comment:
                     if (negate)
                         Comment.NegativeSet.Add(value);
                     else
                         Comment.PositiveSet.Add(value);
                     break;
 
-                // Machine.Description
-                case "gamedesc":
-                case "gamedescription":
-                case "machinedesc":
-                case "machinedescription":
+                case Field.Description:
                     if (negate)
                         MachineDescription.NegativeSet.Add(value);
                     else
                         MachineDescription.PositiveSet.Add(value);
                     break;
 
-                // Machine.Year
-                case "year":
+                case Field.Year:
                     if (negate)
                         Year.NegativeSet.Add(value);
                     else
                         Year.PositiveSet.Add(value);
                     break;
 
-                // Machine.Manufacturer
-                case "manufacturer":
+                case Field.Manufacturer:
                     if (negate)
                         Manufacturer.NegativeSet.Add(value);
                     else
                         Manufacturer.PositiveSet.Add(value);
                     break;
 
-                // Machine.Publisher
-                case "publisher":
+                case Field.Publisher:
                     if (negate)
                         Publisher.NegativeSet.Add(value);
                     else
                         Publisher.PositiveSet.Add(value);
                     break;
 
-                // Machine.Category
-                case "category":
+                case Field.Category:
                     if (negate)
                         Category.NegativeSet.Add(value);
                     else
                         Category.PositiveSet.Add(value);
                     break;
 
-                // Machine.RomOf
-                case "romof":
+                case Field.RomOf:
                     if (negate)
                         RomOf.NegativeSet.Add(value);
                     else
                         RomOf.PositiveSet.Add(value);
                     break;
 
-                // Machine.CloneOf
-                case "cloneof":
+                case Field.CloneOf:
                     if (negate)
                         CloneOf.NegativeSet.Add(value);
                     else
                         CloneOf.PositiveSet.Add(value);
                     break;
 
-                // Machine.SampleOf
-                case "sampleof":
+                case Field.SampleOf:
                     if (negate)
                         SampleOf.NegativeSet.Add(value);
                     else
                         SampleOf.PositiveSet.Add(value);
                     break;
 
-                // Machine.Supported
-                case "supported":
+                case Field.Supported:
                     if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
                         Supported.Neutral = false;
                     else
                         Supported.Neutral = true;
                     break;
 
-                // Machine.SourceFile
-                case "source":
-                case "sourcefile":
+                case Field.SourceFile:
                     if (negate)
                         SourceFile.NegativeSet.Add(value);
                     else
                         SourceFile.PositiveSet.Add(value);
                     break;
 
-                // Machine.Runnable
-                case "runnable":
+                case Field.Runnable:
                     if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
                         Runnable.Neutral = false;
                     else
                         Runnable.Neutral = true;
                     break;
 
-                // Machine.Board
-                case "board":
+                case Field.Board:
                     if (negate)
                         Board.NegativeSet.Add(value);
                     else
                         Board.PositiveSet.Add(value);
                     break;
 
-                // Machine.RebuildTo
-                case "rebuild":
-                case "rebuildto":
+                case Field.RebuildTo:
                     if (negate)
                         RebuildTo.NegativeSet.Add(value);
                     else
                         RebuildTo.PositiveSet.Add(value);
                     break;
 
-                // Machine.MachineType
-                case "gametype":
-                case "machinetype":
+                case Field.MachineType:
                     if (negate)
                         MachineTypes.Negative |= value.AsMachineType();
                     else
@@ -709,9 +461,7 @@ namespace SabreTools.Library.DatFiles
 
                 #region DatItem Filters
 
-                // DatItem.Type
-                case "itemtype":
-                case "type":
+                case Field.ItemType:
                     if (value.AsItemType() == null)
                         return;
 
@@ -721,41 +471,35 @@ namespace SabreTools.Library.DatFiles
                         ItemTypes.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Name
-                case "item":
-                case "itemname":
+                case Field.Name:
                     if (negate)
                         ItemName.NegativeSet.Add(value);
                     else
                         ItemName.PositiveSet.Add(value);
                     break;
 
-                // DatItem.PartName
-                case "partname":
+                case Field.PartName:
                     if (negate)
                         PartName.NegativeSet.Add(value);
                     else
                         PartName.PositiveSet.Add(value);
                     break;
 
-                // DatItem.PartInterface
-                case "partinterface":
+                case Field.PartInterface:
                     if (negate)
                         PartInterface.NegativeSet.Add(value);
                     else
                         PartInterface.PositiveSet.Add(value);
                     break;
 
-                // DatItem.AreaName
-                case "areaname":
+                case Field.AreaName:
                     if (negate)
                         AreaName.NegativeSet.Add(value);
                     else
                         AreaName.PositiveSet.Add(value);
                     break;
 
-                // DatItem.AreaSize
-                case "areasize":
+                case Field.AreaSize:
                     bool? asOperation = null;
                     if (value.StartsWith(">"))
                         asOperation = true;
@@ -807,28 +551,21 @@ namespace SabreTools.Library.DatFiles
 
                     break;
 
-                // DatItem.Default
-                case "default":
+                case Field.Default:
                     if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
                         Default.Neutral = false;
                     else
                         Default.Neutral = true;
                     break;
 
-                // DatItem.Description
-                case "biosdesc":
-                case "biosdescription":
-                case "description":
+                case Field.BiosDescription:
                     if (negate)
                         Description.NegativeSet.Add(value);
                     else
                         Description.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Size
-                case "itemsize":
-                case "romsize":
-                case "size":
+                case Field.Size:
                     bool? sOperation = null;
                     if (value.StartsWith(">"))
                         sOperation = true;
@@ -880,17 +617,14 @@ namespace SabreTools.Library.DatFiles
 
                     break;
 
-                // DatItem.CRC
-                case "crc":
-                case "crc32":
+                case Field.CRC:
                     if (negate)
                         CRC.NegativeSet.Add(value);
                     else
                         CRC.PositiveSet.Add(value);
                     break;
 
-                // DatItem.MD5
-                case "md5":
+                case Field.MD5:
                     if (negate)
                         MD5.NegativeSet.Add(value);
                     else
@@ -898,8 +632,7 @@ namespace SabreTools.Library.DatFiles
                     break;
 
 #if NET_FRAMEWORK
-                // DatItem.RIPEMD160
-                case "ripemd160":
+                case Field.RIPEMD160:
                     if (negate)
                         RIPEMD160.NegativeSet.Add(value);
                     else
@@ -907,119 +640,98 @@ namespace SabreTools.Library.DatFiles
                     break;
 #endif
 
-                // DatItem.SHA1
-                case "sha1":
-                case "sha-1":
+                case Field.SHA1:
                     if (negate)
                         SHA1.NegativeSet.Add(value);
                     else
                         SHA1.PositiveSet.Add(value);
                     break;
 
-                // DatItem.SHA256
-                case "sha256":
-                case "sha-256":
+                case Field.SHA256:
                     if (negate)
                         SHA256.NegativeSet.Add(value);
                     else
                         SHA256.PositiveSet.Add(value);
                     break;
 
-                // DatItem.SHA384
-                case "sha384":
-                case "sha-384":
+                case Field.SHA384:
                     if (negate)
                         SHA384.NegativeSet.Add(value);
                     else
                         SHA384.PositiveSet.Add(value);
                     break;
 
-                // DatItem.SHA512
-                case "sha512":
-                case "sha-512":
+                case Field.SHA512:
                     if (negate)
                         SHA512.NegativeSet.Add(value);
                     else
                         SHA512.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Merge
-                case "merge":
-                case "mergetag":
+                case Field.Merge:
                     if (negate)
                         MergeTag.NegativeSet.Add(value);
                     else
                         MergeTag.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Region
-                case "region":
+                case Field.Region:
                     if (negate)
                         Region.NegativeSet.Add(value);
                     else
                         Region.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Index
-                case "index":
+                case Field.Index:
                     if (negate)
                         Index.NegativeSet.Add(value);
                     else
                         Index.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Writable
-                case "writable":
+                case Field.Writable:
                     if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
                         Writable.Neutral = false;
                     else
                         Writable.Neutral = true;
                     break;
 
-                // DatItem.Optional
-                case "optional":
+                case Field.Optional:
                     if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
                         Optional.Neutral = false;
                     else
                         Optional.Neutral = true;
                     break;
 
-                // DatItem.Status
-                case "itemstatus":
-                case "status":
+                case Field.Status:
                     if (negate)
                         Status.Negative |= value.AsItemStatus();
                     else
                         Status.Positive |= value.AsItemStatus();
                     break;
 
-                // DatItem.Language
-                case "lang":
-                case "language":
+                case Field.Language:
                     if (negate)
                         Language.NegativeSet.Add(value);
                     else
                         Language.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Date
-                case "date":
+                case Field.Date:
                     if (negate)
                         Date.NegativeSet.Add(value);
                     else
                         Date.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Bios
-                case "bios":
+                case Field.Bios:
                     if (negate)
                         Bios.NegativeSet.Add(value);
                     else
                         Bios.PositiveSet.Add(value);
                     break;
 
-                // DatItem.Offset
-                case "offset":
+                case Field.Offset:
                     if (negate)
                         Offset.NegativeSet.Add(value);
                     else

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -41,7 +41,7 @@ namespace SabreTools.Library.DatFiles
             { "Machine.Devices", new FilterItem<string>() }, // TODO: List<string>
             { "Machine.SlotOptions", new FilterItem<string>() }, // TODO: List<string>
             { "Machine.Infos", new FilterItem<string>() }, // TODO: List<KeyValuePair<string, string>>
-            { "Machine.MachineType", new FilterItem<MachineType>()  { Positive = Data.MachineType.NULL, Negative = Data.MachineType.NULL } },
+            { "Machine.MachineType", new FilterItem<MachineType>() { Positive = MachineType.NULL, Negative = MachineType.NULL } },
 
             { "IncludeOfInGame", new FilterItem<bool>() { Neutral = false } },
 
@@ -566,6 +566,591 @@ namespace SabreTools.Library.DatFiles
         #endregion // Pubically facing variables
 
         #region Instance methods
+
+        /// <summary>
+        /// Populate the filters object using a set of key:value filters
+        /// </summary>
+        /// <param name="filters">List of key:value where ~key/!key is negated</param>
+        public void PopulateFromList(List<string> filters)
+        {
+            foreach (string filterPair in filters)
+            {
+                string filterPairTrimmed = filterPair.Trim('"', ' ', '\t');
+                bool negate = filterPairTrimmed.StartsWith("!") || filterPairTrimmed.StartsWith("~");
+                filterPairTrimmed = filterPairTrimmed.TrimStart('!', '~');
+
+                string filterField = filterPairTrimmed.Split(':')[0].ToLowerInvariant().Trim('"', ' ', '\t');
+                string filterValue = filterPairTrimmed.Substring(filterField.Length + 1).Trim('"', ' ', '\t');
+
+                switch (filterField)
+                {
+                    #region Machine Filters
+
+                    // Machine.Name
+                    case "game":
+                    case "gamename":
+                    case "machine":
+                    case "machinename":
+                        if (negate)
+                            MachineName.NegativeSet.Add(filterValue);
+                        else
+                            MachineName.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.Comment
+                    case "comment":
+                        if (negate)
+                            Comment.NegativeSet.Add(filterValue);
+                        else
+                            Comment.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.Description
+                    case "gamedesc":
+                    case "gamedescription":
+                    case "machinedesc":
+                    case "machinedescription":
+                        if (negate)
+                            MachineDescription.NegativeSet.Add(filterValue);
+                        else
+                            MachineDescription.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.Year
+                    case "year":
+                        if (negate)
+                            Year.NegativeSet.Add(filterValue);
+                        else
+                            Year.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.Manufacturer
+                    case "manufacturer":
+                        if (negate)
+                            Manufacturer.NegativeSet.Add(filterValue);
+                        else
+                            Manufacturer.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.Publisher
+                    case "publisher":
+                        if (negate)
+                            Publisher.NegativeSet.Add(filterValue);
+                        else
+                            Publisher.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.Category
+                    case "category":
+                        if (negate)
+                            Category.NegativeSet.Add(filterValue);
+                        else
+                            Category.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.RomOf
+                    case "romof":
+                        if (negate)
+                            RomOf.NegativeSet.Add(filterValue);
+                        else
+                            RomOf.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.CloneOf
+                    case "cloneof":
+                        if (negate)
+                            CloneOf.NegativeSet.Add(filterValue);
+                        else
+                            CloneOf.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.SampleOf
+                    case "sampleof":
+                        if (negate)
+                            SampleOf.NegativeSet.Add(filterValue);
+                        else
+                            SampleOf.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.Supported
+                    case "supported":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            Supported.Neutral = false;
+                        else
+                            Supported.Neutral = true;
+                        break;
+
+                    // Machine.SourceFile
+                    case "source":
+                    case "sourcefile":
+                        if (negate)
+                            SourceFile.NegativeSet.Add(filterValue);
+                        else
+                            SourceFile.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.Runnable
+                    case "runnable":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            Runnable.Neutral = false;
+                        else
+                            Runnable.Neutral = true;
+                        break;
+
+                    // Machine.Board
+                    case "board":
+                        if (negate)
+                            Board.NegativeSet.Add(filterValue);
+                        else
+                            Board.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.RebuildTo
+                    case "rebuild":
+                    case "rebuildto":
+                        if (negate)
+                            RebuildTo.NegativeSet.Add(filterValue);
+                        else
+                            RebuildTo.PositiveSet.Add(filterValue);
+                        break;
+
+                    // Machine.MachineType
+                    case "gametype":
+                    case "machinetype":
+                        if (negate)
+                            MachineTypes.Negative |= filterValue.AsMachineType();
+                        else
+                            MachineTypes.Positive |= filterValue.AsMachineType();
+                        break;
+
+                    // IncludeOfInGame
+                    case "includeofingame":
+                    case "matchoftags":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            IncludeOfInGame.Neutral = false;
+                        else
+                            IncludeOfInGame.Neutral = true;
+                        break;
+
+                    #endregion
+
+                    #region DatItem Filters
+
+                    // DatItem.Type
+                    case "itemtype":
+                    case "type":
+                        if (filterValue.AsItemType() == null)
+                            continue;
+
+                        if (negate)
+                            ItemTypes.NegativeSet.Add(filterValue);
+                        else
+                            ItemTypes.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Name
+                    case "item":
+                    case "itemname":
+                        if (negate)
+                            ItemName.NegativeSet.Add(filterValue);
+                        else
+                            ItemName.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.PartName
+                    case "partname":
+                        if (negate)
+                            PartName.NegativeSet.Add(filterValue);
+                        else
+                            PartName.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.PartInterface
+                    case "partinterface":
+                        if (negate)
+                            PartInterface.NegativeSet.Add(filterValue);
+                        else
+                            PartInterface.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.AreaName
+                    case "areaname":
+                        if (negate)
+                            AreaName.NegativeSet.Add(filterValue);
+                        else
+                            AreaName.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.AreaSize
+                    case "areasize":
+                        bool? asOperation = null;
+                        if (filterValue.StartsWith(">"))
+                            asOperation = true;
+                        else if (filterValue.StartsWith("<"))
+                            asOperation = false;
+                        else if (filterValue.StartsWith("="))
+                            asOperation = null;
+
+                        string areasizeString = filterValue.TrimStart('>', '<', '=');
+                        if (!Int64.TryParse(areasizeString, out long areasize))
+                            continue;
+
+                        // Equal
+                        if (asOperation == null && !negate)
+                        {
+                            AreaSize.Neutral = areasize;
+                        }
+
+                        // Not Equal
+                        else if (asOperation == null && negate)
+                        {
+                            AreaSize.Negative = areasize - 1;
+                            AreaSize.Positive = areasize + 1;
+                        }
+
+                        // Greater Than or Equal
+                        else if (asOperation == true && !negate)
+                        {
+                            AreaSize.Positive = areasize;
+                        }
+
+                        // Strictly Less Than
+                        else if (asOperation == true && negate)
+                        {
+                            AreaSize.Negative = areasize - 1;
+                        }
+
+                        // Less Than or Equal
+                        else if (asOperation == false && !negate)
+                        {
+                            AreaSize.Negative = areasize;
+                        }
+
+                        // Strictly Greater Than
+                        else if (asOperation == false && negate)
+                        {
+                            AreaSize.Positive = areasize + 1;
+                        }
+
+                        break;
+
+                    // DatItem.Default
+                    case "default":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            Default.Neutral = false;
+                        else
+                            Default.Neutral = true;
+                        break;
+
+                    // DatItem.Description
+                    case "biosdesc":
+                    case "biosdescription":
+                    case "description":
+                        if (negate)
+                            Description.NegativeSet.Add(filterValue);
+                        else
+                            Description.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Size
+                    case "itemsize":
+                    case "romsize":
+                    case "size":
+                        bool? sOperation = null;
+                        if (filterValue.StartsWith(">"))
+                            sOperation = true;
+                        else if (filterValue.StartsWith("<"))
+                            sOperation = false;
+                        else if (filterValue.StartsWith("="))
+                            sOperation = null;
+
+                        string sizeString = filterValue.TrimStart('>', '<', '=');
+                        if (!Int64.TryParse(sizeString, out long size))
+                            continue;
+
+                        // Equal
+                        if (sOperation == null && !negate)
+                        {
+                            Size.Neutral = size;
+                        }
+
+                        // Not Equal
+                        else if (sOperation == null && negate)
+                        {
+                            Size.Negative = size - 1;
+                            Size.Positive = size + 1;
+                        }
+
+                        // Greater Than or Equal
+                        else if (sOperation == true && !negate)
+                        {
+                            Size.Positive = size;
+                        }
+
+                        // Strictly Less Than
+                        else if (sOperation == true && negate)
+                        {
+                            Size.Negative = size - 1;
+                        }
+
+                        // Less Than or Equal
+                        else if (sOperation == false && !negate)
+                        {
+                            Size.Negative = size;
+                        }
+
+                        // Strictly Greater Than
+                        else if (sOperation == false && negate)
+                        {
+                            Size.Positive = size + 1;
+                        }
+
+                        break;
+
+                    // DatItem.CRC
+                    case "crc":
+                    case "crc32":
+                        if (negate)
+                            CRC.NegativeSet.Add(filterValue);
+                        else
+                            CRC.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.MD5
+                    case "md5":
+                        if (negate)
+                            MD5.NegativeSet.Add(filterValue);
+                        else
+                            MD5.PositiveSet.Add(filterValue);
+                        break;
+
+#if NET_FRAMEWORK
+                    // DatItem.RIPEMD160
+                    case "ripemd160":
+                        if (negate)
+                            RIPEMD160.NegativeSet.Add(filterValue);
+                        else
+                            RIPEMD160.PositiveSet.Add(filterValue);
+                        break;
+#endif
+
+                    // DatItem.SHA1
+                    case "sha1":
+                    case "sha-1":
+                        if (negate)
+                            SHA1.NegativeSet.Add(filterValue);
+                        else
+                            SHA1.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.SHA256
+                    case "sha256":
+                    case "sha-256":
+                        if (negate)
+                            SHA256.NegativeSet.Add(filterValue);
+                        else
+                            SHA256.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.SHA384
+                    case "sha384":
+                    case "sha-384":
+                        if (negate)
+                            SHA384.NegativeSet.Add(filterValue);
+                        else
+                            SHA384.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.SHA512
+                    case "sha512":
+                    case "sha-512":
+                        if (negate)
+                            SHA512.NegativeSet.Add(filterValue);
+                        else
+                            SHA512.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Merge
+                    case "merge":
+                    case "mergetag":
+                        if (negate)
+                            MergeTag.NegativeSet.Add(filterValue);
+                        else
+                            MergeTag.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Region
+                    case "region":
+                        if (negate)
+                            Region.NegativeSet.Add(filterValue);
+                        else
+                            Region.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Index
+                    case "index":
+                        if (negate)
+                            Index.NegativeSet.Add(filterValue);
+                        else
+                            Index.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Writable
+                    case "writable":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            Writable.Neutral = false;
+                        else
+                            Writable.Neutral = true;
+                        break;
+
+                    // DatItem.Optional
+                    case "optional":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            Optional.Neutral = false;
+                        else
+                            Optional.Neutral = true;
+                        break;
+
+                    // DatItem.Status
+                    case "itemstatus":
+                    case "status":
+                        if (negate)
+                            Status.Negative |= filterValue.AsItemStatus();
+                        else
+                            Status.Positive |= filterValue.AsItemStatus();
+                        break;
+
+                    // DatItem.Language
+                    case "lang":
+                    case "language":
+                        if (negate)
+                            Language.NegativeSet.Add(filterValue);
+                        else
+                            Language.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Date
+                    case "date":
+                        if (negate)
+                            Date.NegativeSet.Add(filterValue);
+                        else
+                            Date.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Bios
+                    case "bios":
+                        if (negate)
+                            Bios.NegativeSet.Add(filterValue);
+                        else
+                            Bios.PositiveSet.Add(filterValue);
+                        break;
+
+                    // DatItem.Offset
+                    case "offset":
+                        if (negate)
+                            Offset.NegativeSet.Add(filterValue);
+                        else
+                            Offset.PositiveSet.Add(filterValue);
+                        break;
+
+                    #endregion
+
+                    #region Manipulation Filters
+
+                    // Clean
+                    case "clean":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            Clean.Neutral = false;
+                        else
+                            Clean.Neutral = true;
+                        break;
+
+                    // DescriptionAsName
+                    case "descasname":
+                    case "descriptionasname":
+                    case "descriptionasgamename":
+                    case "descriptionasmachinename":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            DescriptionAsName.Neutral = false;
+                        else
+                            DescriptionAsName.Neutral = true;
+                        break;
+
+                    // InternalSplit
+                    case "internalsplit":
+                    case "split":
+                        SplitType splitType = SplitType.None;
+                        switch (filterValue.ToLowerInvariant())
+                        {
+                            case "dnm":
+                            case "devicenonmerged":
+                                splitType = SplitType.DeviceNonMerged;
+                                break;
+
+                            case "fnm":
+                            case "fullnonmerged":
+                                splitType = SplitType.FullNonMerged;
+                                break;
+
+                            case "m":
+                            case "merge":
+                            case "merged":
+                                splitType = SplitType.Merged;
+                                break;
+
+                            case "nm":
+                            case "nonmerged":
+                                splitType = SplitType.NonMerged;
+                                break;
+
+                            case "s":
+                            case "split":
+                                splitType = SplitType.Split;
+                                break;
+                        }
+
+                        if (negate)
+                            InternalSplit.Neutral = splitType;
+                        else
+                            InternalSplit.Neutral = splitType;
+                        break;
+
+                    // RemoveUnicode
+                    case "remunicode":
+                    case "removeunicode":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            RemoveUnicode.Neutral = false;
+                        else
+                            RemoveUnicode.Neutral = true;
+                        break;
+
+                    // Root
+                    case "root":
+                    case "rootdir":
+                        Root.Neutral = filterValue;
+                        break;
+
+                    // Single
+                    case "single":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            Single.Neutral = false;
+                        else
+                            Single.Neutral = true;
+                        break;
+
+                    // Trim
+                    case "trim":
+                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                            Trim.Neutral = false;
+                        else
+                            Trim.Neutral = true;
+                        break;
+
+
+                        #endregion
+                }
+            }
+        }
 
         /// <summary>
         /// Filter a DatFile using the inputs

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -543,6 +543,20 @@ namespace SabreTools.Library.DatFiles
         }
 
         /// <summary>
+        /// Set multiple filters from key
+        /// </summary>
+        /// <param name="key">Key for the filter to be set</param>
+        /// <param name="values">List of values for the filter</param>
+        /// <param name="negate">True if negative filter, false otherwise</param>
+        public void SetFilter(string key, List<string> values, bool negate)
+        {
+            foreach (string value in values)
+            {
+                SetFilter(key, value, negate);
+            }
+        }
+
+        /// <summary>
         /// Set a single filter from key
         /// </summary>
         /// <param name="key">Key for the filter to be set</param>

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -307,8 +307,8 @@ namespace SabreTools.Library.DatFiles
         /// </summary>
         public FilterItem<long?> AreaSize
         {
-            get { return Filters["DatItem.AreaName"] as FilterItem<long?>; }
-            set { Filters["DatItem.AreaName"] = value; }
+            get { return Filters["DatItem.AreaSize"] as FilterItem<long?>; }
+            set { Filters["DatItem.AreaSize"] = value; }
         }
 
         /// <summary>
@@ -797,6 +797,7 @@ namespace SabreTools.Library.DatFiles
             #region DatItem Filters
 
             // Filter on item type
+            // TODO: Remove default filtering at some point
             if (this.ItemTypes.PositiveSet.Count == 0 && this.ItemTypes.NegativeSet.Count == 0
                 && item.ItemType != ItemType.Rom && item.ItemType != ItemType.Disk && item.ItemType != ItemType.Blank)
                 return false;

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -43,8 +43,6 @@ namespace SabreTools.Library.DatFiles
             { "Machine.Infos", new FilterItem<string>() }, // TODO: List<KeyValuePair<string, string>>
             { "Machine.MachineType", new FilterItem<MachineType>() { Positive = MachineType.NULL, Negative = MachineType.NULL } },
 
-            { "IncludeOfInGame", new FilterItem<bool>() { Neutral = false } },
-
             #endregion
 
             #region DatItem Filters
@@ -78,18 +76,6 @@ namespace SabreTools.Library.DatFiles
             { "DatItem.Date", new FilterItem<string>() },
             { "DatItem.Bios", new FilterItem<string>() },
             { "DatItem.Offset", new FilterItem<string>() },
-
-            #endregion
-
-            #region Manipulation Filters
-
-            { "Clean", new FilterItem<bool>() { Neutral = false } },
-            { "DescriptionAsName", new FilterItem<bool>() { Neutral = false } },
-            { "InternalSplit", new FilterItem<SplitType>() { Neutral = SplitType.None } },
-            { "RemoveUnicode", new FilterItem<bool>() { Neutral = false } },
-            { "Root", new FilterItem<string>() { Neutral = null } },
-            { "Single", new FilterItem<bool>() { Neutral = false } },
-            { "Trim", new FilterItem<bool>() { Neutral = false } },
 
             #endregion
         };
@@ -242,15 +228,6 @@ namespace SabreTools.Library.DatFiles
         {
             get { return Filters["Machine.MachineType"] as FilterItem<MachineType>; }
             set { Filters["Machine.MachineType"] = value; }
-        }
-
-        /// <summary>
-        /// Include romof and cloneof when filtering machine names
-        /// </summary>
-        public FilterItem<bool> IncludeOfInGame
-        {
-            get { return Filters["IncludeOfInGame"] as FilterItem<bool>; }
-            set { Filters["IncludeOfInGame"] = value; }
         }
 
         #endregion
@@ -496,70 +473,48 @@ namespace SabreTools.Library.DatFiles
 
         #endregion
 
-        #region Manipulation Filters
+        // TODO: Should these actually be FilterItems? It seems needless
+        #region Manipulation Flags
 
         /// <summary>
         /// Clean all names to WoD standards
         /// </summary>
-        public FilterItem<bool> Clean
-        {
-            get { return Filters["Clean"] as FilterItem<bool>; }
-            set { Filters["Clean"] = value; }
-        }
+        public bool Clean { get; set; }
 
         /// <summary>
         /// Set Machine Description from Machine Name
         /// </summary>
-        public FilterItem<bool> DescriptionAsName
-        {
-            get { return Filters["DescriptionAsName"] as FilterItem<bool>; }
-            set { Filters["DescriptionAsName"] = value; }
-        }
+        public bool DescriptionAsName { get; set; }
+
+        /// <summary>
+        /// Include romof and cloneof when filtering machine names
+        /// </summary>
+        public bool IncludeOfInGame { get; set; }
 
         /// <summary>
         /// Internally split a DatFile
         /// </summary>
-        public FilterItem<SplitType> InternalSplit
-        {
-            get { return Filters["InternalSplit"] as FilterItem<SplitType>; }
-            set { Filters["InternalSplit"] = value; }
-        }
+        public SplitType InternalSplit { get; set; }
 
         /// <summary>
         /// Remove all unicode characters
         /// </summary>
-        public FilterItem<bool> RemoveUnicode
-        {
-            get { return Filters["RemoveUnicode"] as FilterItem<bool>; }
-            set { Filters["RemoveUnicode"] = value; }
-        }
+        public bool RemoveUnicode { get; set; }
 
         /// <summary>
         /// Include root directory when determing trim sizes
         /// </summary>
-        public FilterItem<string> Root
-        {
-            get { return Filters["Root"] as FilterItem<string>; }
-            set { Filters["Root"] = value; }
-        }
+        public string Root { get; set; }
 
         /// <summary>
         /// Change all machine names to "!"
         /// </summary>
-        public FilterItem<bool> Single
-        {
-            get { return Filters["Single"] as FilterItem<bool>; }
-            set { Filters["Single"] = value; }
-        }
+        public bool Single { get; set; }
 
         /// <summary>
         /// Trim total machine and item name to not exceed NTFS limits
         /// </summary>
-        public FilterItem<bool> Trim
-        {
-            get { return Filters["Trim"] as FilterItem<bool>; }
-            set { Filters["Trim"] = value; }
-        }
+        public bool Trim { get; set; }
 
         #endregion
 
@@ -721,15 +676,6 @@ namespace SabreTools.Library.DatFiles
                             MachineTypes.Negative |= filterValue.AsMachineType();
                         else
                             MachineTypes.Positive |= filterValue.AsMachineType();
-                        break;
-
-                    // IncludeOfInGame
-                    case "includeofingame":
-                    case "matchoftags":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            IncludeOfInGame.Neutral = false;
-                        else
-                            IncludeOfInGame.Neutral = true;
                         break;
 
                     #endregion
@@ -1054,100 +1000,6 @@ namespace SabreTools.Library.DatFiles
                         break;
 
                     #endregion
-
-                    #region Manipulation Filters
-
-                    // Clean
-                    case "clean":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            Clean.Neutral = false;
-                        else
-                            Clean.Neutral = true;
-                        break;
-
-                    // DescriptionAsName
-                    case "descasname":
-                    case "descriptionasname":
-                    case "descriptionasgamename":
-                    case "descriptionasmachinename":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            DescriptionAsName.Neutral = false;
-                        else
-                            DescriptionAsName.Neutral = true;
-                        break;
-
-                    // InternalSplit
-                    case "internalsplit":
-                    case "split":
-                        SplitType splitType = SplitType.None;
-                        switch (filterValue.ToLowerInvariant())
-                        {
-                            case "dnm":
-                            case "devicenonmerged":
-                                splitType = SplitType.DeviceNonMerged;
-                                break;
-
-                            case "fnm":
-                            case "fullnonmerged":
-                                splitType = SplitType.FullNonMerged;
-                                break;
-
-                            case "m":
-                            case "merge":
-                            case "merged":
-                                splitType = SplitType.Merged;
-                                break;
-
-                            case "nm":
-                            case "nonmerged":
-                                splitType = SplitType.NonMerged;
-                                break;
-
-                            case "s":
-                            case "split":
-                                splitType = SplitType.Split;
-                                break;
-                        }
-
-                        if (negate)
-                            InternalSplit.Neutral = splitType;
-                        else
-                            InternalSplit.Neutral = splitType;
-                        break;
-
-                    // RemoveUnicode
-                    case "remunicode":
-                    case "removeunicode":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            RemoveUnicode.Neutral = false;
-                        else
-                            RemoveUnicode.Neutral = true;
-                        break;
-
-                    // Root
-                    case "root":
-                    case "rootdir":
-                        Root.Neutral = filterValue;
-                        break;
-
-                    // Single
-                    case "single":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            Single.Neutral = false;
-                        else
-                            Single.Neutral = true;
-                        break;
-
-                    // Trim
-                    case "trim":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            Trim.Neutral = false;
-                        else
-                            Trim.Neutral = true;
-                        break;
-
-
-                        #endregion
                 }
             }
         }
@@ -1175,7 +1027,7 @@ namespace SabreTools.Library.DatFiles
                         if (ItemPasses(item))
                         {
                             // If we're stripping unicode characters, do so from all relevant things
-                            if (this.RemoveUnicode.Neutral)
+                            if (this.RemoveUnicode)
                             {
                                 item.Name = Sanitizer.RemoveUnicodeCharacters(item.Name);
                                 item.MachineName = Sanitizer.RemoveUnicodeCharacters(item.MachineName);
@@ -1183,21 +1035,21 @@ namespace SabreTools.Library.DatFiles
                             }
 
                             // If we're in cleaning mode, do so from all relevant things
-                            if (this.Clean.Neutral)
+                            if (this.Clean)
                             {
                                 item.MachineName = Sanitizer.CleanGameName(item.MachineName);
                                 item.MachineDescription = Sanitizer.CleanGameName(item.MachineDescription);
                             }
 
                             // If we are in single game mode, rename all games
-                            if (this.Single.Neutral)
+                            if (this.Single)
                                 item.MachineName = "!";
 
                             // If we are in NTFS trim mode, trim the game name
-                            if (this.Trim.Neutral)
+                            if (this.Trim)
                             {
                                 // Windows max name length is 260
-                                int usableLength = 260 - item.MachineName.Length - this.Root.Neutral.Length;
+                                int usableLength = 260 - item.MachineName.Length - this.Root.Length;
                                 if (item.Name.Length > usableLength)
                                 {
                                     string ext = Path.GetExtension(item.Name);
@@ -1219,15 +1071,15 @@ namespace SabreTools.Library.DatFiles
                 }
 
                 // Process description to machine name
-                if (this.DescriptionAsName.Neutral)
+                if (this.DescriptionAsName)
                     MachineDescriptionToName(datFile);
 
                 // If we are using tags from the DAT, set the proper input for split type unless overridden
-                if (useTags && this.InternalSplit.Neutral == SplitType.None)
-                    this.InternalSplit.Neutral = datFile.DatHeader.ForceMerging.AsSplitType();
+                if (useTags && this.InternalSplit == SplitType.None)
+                    this.InternalSplit = datFile.DatHeader.ForceMerging.AsSplitType();
 
                 // Run internal splitting
-                ProcessSplitType(datFile, this.InternalSplit.Neutral);
+                ProcessSplitType(datFile, this.InternalSplit);
 
                 // We remove any blanks, if we aren't supposed to have any
                 if (!datFile.DatHeader.KeepEmptyGames)
@@ -1274,7 +1126,7 @@ namespace SabreTools.Library.DatFiles
 
             // Filter on machine name
             bool? machineNameFound = this.MachineName.MatchesPositiveSet(item.MachineName);
-            if (this.IncludeOfInGame.Neutral)
+            if (this.IncludeOfInGame)
             {
                 machineNameFound |= (this.MachineName.MatchesPositiveSet(item.CloneOf) == true);
                 machineNameFound |= (this.MachineName.MatchesPositiveSet(item.RomOf) == true);
@@ -1283,7 +1135,7 @@ namespace SabreTools.Library.DatFiles
                 return false;
 
             machineNameFound = this.MachineName.MatchesNegativeSet(item.MachineName);
-            if (this.IncludeOfInGame.Neutral)
+            if (this.IncludeOfInGame)
             {
                 machineNameFound |= (this.MachineName.MatchesNegativeSet(item.CloneOf) == true);
                 machineNameFound |= (this.MachineName.MatchesNegativeSet(item.RomOf) == true);

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -311,8 +311,11 @@ namespace SabreTools.Library.DatFiles
             foreach (string filterPair in filters)
             {
                 string filterPairTrimmed = filterPair.Trim('"', ' ', '\t');
-                bool negate = filterPairTrimmed.StartsWith("!") || filterPairTrimmed.StartsWith("~");
+                bool negate = filterPairTrimmed.StartsWith("!")
+                    || filterPairTrimmed.StartsWith("~")
+                    || filterPairTrimmed.StartsWith("not-");
                 filterPairTrimmed = filterPairTrimmed.TrimStart('!', '~');
+                filterPairTrimmed = filterPairTrimmed.StartsWith("not-") ? filterPairTrimmed.Substring(4) : filterPairTrimmed;
 
                 string filterFieldString = filterPairTrimmed.Split(':')[0].ToLowerInvariant().Trim('"', ' ', '\t');
                 string filterValue = filterPairTrimmed.Substring(filterFieldString.Length + 1).Trim('"', ' ', '\t');

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -38,10 +38,10 @@ namespace SabreTools.Library.DatFiles
             { "Machine.Runnable", new FilterItem<bool?>() { Neutral = null } },
             { "Machine.Board", new FilterItem<string>() },
             { "Machine.RebuildTo", new FilterItem<string>() },
-            { "Machine.Devices", new FilterItem<string>() }, // List<string>
-            { "Machine.SlotOptions", new FilterItem<string>() }, // List<string>
-            { "Machine.Infos", new FilterItem<string>() }, // List<KeyValuePair<string, string>>
-            { "Machine.MachineType", new FilterItem<MachineType>()  { Positive = MachineType.NULL, Negative = MachineType.NULL } },
+            { "Machine.Devices", new FilterItem<string>() }, // TODO: List<string>
+            { "Machine.SlotOptions", new FilterItem<string>() }, // TODO: List<string>
+            { "Machine.Infos", new FilterItem<string>() }, // TODO: List<KeyValuePair<string, string>>
+            { "Machine.MachineType", new FilterItem<MachineType>()  { Positive = Data.MachineType.NULL, Negative = Data.MachineType.NULL } },
 
             { "IncludeOfInGame", new FilterItem<bool>() { Neutral = false } },
 
@@ -53,9 +53,9 @@ namespace SabreTools.Library.DatFiles
             { "DatItem.Name", new FilterItem<string>() },
             { "DatItem.PartName", new FilterItem<string>() },
             { "DatItem.PartInterface", new FilterItem<string>() },
-            { "DatItem.Features", new FilterItem<string>() }, // List<KeyValuePair<string, string>>
+            { "DatItem.Features", new FilterItem<string>() }, // TODO: List<KeyValuePair<string, string>>
             { "DatItem.AreaName", new FilterItem<string>() },
-            { "DatItem.AreaSize", new FilterItem<long?>() },
+            { "DatItem.AreaSize", new FilterItem<long?>() { Positive = null, Negative = null, Neutral = null } },
             { "DatItem.Default", new FilterItem<bool?>() { Neutral = null } },
             { "DatItem.Description", new FilterItem<string>() },
             { "DatItem.Size", new FilterItem<long>() { Positive = -1, Negative = -1, Neutral = -1 } },
@@ -101,15 +101,6 @@ namespace SabreTools.Library.DatFiles
         #region Machine Filters
 
         /// <summary>
-        /// Include or exclude categories
-        /// </summary>
-        public FilterItem<string> Category
-        {
-            get { return Filters["Machine.Category"] as FilterItem<string>; }
-            set { Filters["Machine.Category"] = value; }
-        }
-
-        /// <summary>
         /// Include or exclude machine names
         /// </summary>
         public FilterItem<string> MachineName
@@ -119,12 +110,12 @@ namespace SabreTools.Library.DatFiles
         }
 
         /// <summary>
-        /// Include romof and cloneof when filtering machine names
+        /// Include or exclude machine comments
         /// </summary>
-        public FilterItem<bool> IncludeOfInGame
+        public FilterItem<string> Comment
         {
-            get { return Filters["IncludeOfInGame"] as FilterItem<bool>; }
-            set { Filters["IncludeOfInGame"] = value; }
+            get { return Filters["Machine.Comment"] as FilterItem<string>; }
+            set { Filters["Machine.Comment"] = value; }
         }
 
         /// <summary>
@@ -137,12 +128,84 @@ namespace SabreTools.Library.DatFiles
         }
 
         /// <summary>
-        /// Include or exclude machine types
+        /// Include or exclude machine years
         /// </summary>
-        public FilterItem<MachineType> MachineTypes
+        public FilterItem<string> Year
         {
-            get { return Filters["Machine.MachineType"] as FilterItem<MachineType>; }
-            set { Filters["Machine.MachineType"] = value; }
+            get { return Filters["Machine.Year"] as FilterItem<string>; }
+            set { Filters["Machine.Year"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine manufacturers
+        /// </summary>
+        public FilterItem<string> Manufacturer
+        {
+            get { return Filters["Machine.Manufacturer"] as FilterItem<string>; }
+            set { Filters["Machine.Manufacturer"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine publishers
+        /// </summary>
+        public FilterItem<string> Publisher
+        {
+            get { return Filters["Machine.Publisher"] as FilterItem<string>; }
+            set { Filters["Machine.Publisher"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine categories
+        /// </summary>
+        public FilterItem<string> Category
+        {
+            get { return Filters["Machine.Category"] as FilterItem<string>; }
+            set { Filters["Machine.Category"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine romof
+        /// </summary>
+        public FilterItem<string> RomOf
+        {
+            get { return Filters["Machine.RomOf"] as FilterItem<string>; }
+            set { Filters["Machine.RomOf"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine cloneof
+        /// </summary>
+        public FilterItem<string> CloneOf
+        {
+            get { return Filters["Machine.CloneOf"] as FilterItem<string>; }
+            set { Filters["Machine.CloneOf"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine sampleof
+        /// </summary>
+        public FilterItem<string> SampleOf
+        {
+            get { return Filters["Machine.SampleOf"] as FilterItem<string>; }
+            set { Filters["Machine.SampleOf"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude items with the "Supported" tag
+        /// </summary>
+        public FilterItem<bool?> Supported
+        {
+            get { return Filters["Machine.Supported"] as FilterItem<bool?>; }
+            set { Filters["Machine.Supported"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine source file
+        /// </summary>
+        public FilterItem<string> SourceFile
+        {
+            get { return Filters["Machine.SourceFile"] as FilterItem<string>; }
+            set { Filters["Machine.SourceFile"] = value; }
         }
 
         /// <summary>
@@ -154,9 +217,54 @@ namespace SabreTools.Library.DatFiles
             set { Filters["Machine.Runnable"] = value; }
         }
 
+        /// <summary>
+        /// Include or exclude machine board
+        /// </summary>
+        public FilterItem<string> Board
+        {
+            get { return Filters["Machine.Board"] as FilterItem<string>; }
+            set { Filters["Machine.Board"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine rebuildto
+        /// </summary>
+        public FilterItem<string> RebuildTo
+        {
+            get { return Filters["Machine.RebuildTo"] as FilterItem<string>; }
+            set { Filters["Machine.RebuildTo"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude machine types
+        /// </summary>
+        public FilterItem<MachineType> MachineTypes
+        {
+            get { return Filters["Machine.MachineType"] as FilterItem<MachineType>; }
+            set { Filters["Machine.MachineType"] = value; }
+        }
+
+        /// <summary>
+        /// Include romof and cloneof when filtering machine names
+        /// </summary>
+        public FilterItem<bool> IncludeOfInGame
+        {
+            get { return Filters["IncludeOfInGame"] as FilterItem<bool>; }
+            set { Filters["IncludeOfInGame"] = value; }
+        }
+
         #endregion
 
         #region DatItem Filters
+
+        /// <summary>
+        /// Include or exclude item types
+        /// </summary>
+        public FilterItem<string> ItemTypes
+        {
+            get { return Filters["DatItem.Type"] as FilterItem<string>; }
+            set { Filters["DatItem.Type"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude item names
@@ -168,12 +276,57 @@ namespace SabreTools.Library.DatFiles
         }
 
         /// <summary>
-        /// Include or exclude item types
+        /// Include or exclude part names
         /// </summary>
-        public FilterItem<string> ItemTypes
+        public FilterItem<string> PartName
         {
-            get { return Filters["DatItem.Type"] as FilterItem<string>; }
-            set { Filters["DatItem.Type"] = value; }
+            get { return Filters["DatItem.PartName"] as FilterItem<string>; }
+            set { Filters["DatItem.PartName"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude part interfaces
+        /// </summary>
+        public FilterItem<string> PartInterface
+        {
+            get { return Filters["DatItem.PartInterface"] as FilterItem<string>; }
+            set { Filters["DatItem.PartInterface"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude area names
+        /// </summary>
+        public FilterItem<string> AreaName
+        {
+            get { return Filters["DatItem.AreaName"] as FilterItem<string>; }
+            set { Filters["DatItem.AreaName"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude area sizes
+        /// </summary>
+        public FilterItem<long?> AreaSize
+        {
+            get { return Filters["DatItem.AreaName"] as FilterItem<long?>; }
+            set { Filters["DatItem.AreaName"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude items with the "Default" tag
+        /// </summary>
+        public FilterItem<bool?> Default
+        {
+            get { return Filters["DatItem.Default"] as FilterItem<bool?>; }
+            set { Filters["DatItem.Default"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude descriptions
+        /// </summary>
+        public FilterItem<string> Description
+        {
+            get { return Filters["DatItem.Description"] as FilterItem<string>; }
+            set { Filters["DatItem.Description"] = value; }
         }
 
         /// <summary>
@@ -252,12 +405,93 @@ namespace SabreTools.Library.DatFiles
         }
 
         /// <summary>
+        /// Include or exclude merge tags
+        /// </summary>
+        public FilterItem<string> MergeTag
+        {
+            get { return Filters["DatItem.Merge"] as FilterItem<string>; }
+            set { Filters["DatItem.Merge"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude regions
+        /// </summary>
+        public FilterItem<string> Region
+        {
+            get { return Filters["DatItem.Region"] as FilterItem<string>; }
+            set { Filters["DatItem.Region"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude indexes
+        /// </summary>
+        public FilterItem<string> Index
+        {
+            get { return Filters["DatItem.Index"] as FilterItem<string>; }
+            set { Filters["DatItem.Index"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude items with the "Writable" tag
+        /// </summary>
+        public FilterItem<bool?> Writable
+        {
+            get { return Filters["DatItem.Writable"] as FilterItem<bool?>; }
+            set { Filters["DatItem.Writable"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude items with the "Writable" tag
+        /// </summary>
+        public FilterItem<bool?> Optional
+        {
+            get { return Filters["DatItem.Optional"] as FilterItem<bool?>; }
+            set { Filters["DatItem.Optional"] = value; }
+        }
+
+        /// <summary>
         /// Include or exclude item statuses
         /// </summary>
-        public FilterItem<ItemStatus> ItemStatuses
+        public FilterItem<ItemStatus> Status
         {
             get { return Filters["DatItem.Status"] as FilterItem<ItemStatus>; }
             set { Filters["DatItem.Status"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude languages
+        /// </summary>
+        public FilterItem<string> Language
+        {
+            get { return Filters["DatItem.Language"] as FilterItem<string>; }
+            set { Filters["DatItem.Language"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude dates
+        /// </summary>
+        public FilterItem<string> Date
+        {
+            get { return Filters["DatItem.Date"] as FilterItem<string>; }
+            set { Filters["DatItem.Date"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude bioses
+        /// </summary>
+        public FilterItem<string> Bios
+        {
+            get { return Filters["DatItem.Bios"] as FilterItem<string>; }
+            set { Filters["DatItem.Bios"] = value; }
+        }
+
+        /// <summary>
+        /// Include or exclude offsets
+        /// </summary>
+        public FilterItem<string> Offset
+        {
+            get { return Filters["DatItem.Offset"] as FilterItem<string>; }
+            set { Filters["DatItem.Offset"] = value; }
         }
 
         #endregion
@@ -451,133 +685,7 @@ namespace SabreTools.Library.DatFiles
             if (item == null)
                 return false;
 
-            // Filter on machine type
-            if (this.MachineTypes.MatchesPositive(MachineType.NULL, item.MachineType) == false)
-                return false;
-            if (this.MachineTypes.MatchesNegative(MachineType.NULL, item.MachineType) == true)
-                return false;
-
-            // Filter on machine category
-            if (this.Category.MatchesPositiveSet(item.Category) == false)
-                return false;
-            if (this.Category.MatchesNegativeSet(item.Category) == true)
-                return false;
-
-            // Filter on machine runability
-            if (this.Runnable.MatchesNeutral(null, item.Runnable) == false)
-                return false;
-
-            // Take care of Rom and Disk specific differences
-            if (item.ItemType == ItemType.Rom)
-            {
-                Rom rom = (Rom)item;
-
-                // Filter on status
-                if (this.ItemStatuses.MatchesPositive(ItemStatus.NULL, rom.ItemStatus) == false)
-                    return false;
-                if (this.ItemStatuses.MatchesNegative(ItemStatus.NULL, rom.ItemStatus) == true)
-                    return false;
-
-                // Filter on rom size
-                if (this.Size.MatchesNeutral(-1, rom.Size) == false)
-                    return false;
-                else if (this.Size.MatchesPositive(-1, rom.Size) == false)
-                    return false;
-                else if (this.Size.MatchesNegative(-1, rom.Size) == false)
-                    return false;
-
-                // Filter on CRC
-                if (this.CRC.MatchesPositiveSet(rom.CRC) == false)
-                    return false;
-                if (this.CRC.MatchesNegativeSet(rom.CRC) == true)
-                    return false;
-
-                // Filter on MD5
-                if (this.MD5.MatchesPositiveSet(rom.MD5) == false)
-                    return false;
-                if (this.MD5.MatchesNegativeSet(rom.MD5) == true)
-                    return false;
-
-#if NET_FRAMEWORK
-                // Filter on RIPEMD160
-                if (this.RIPEMD160.MatchesPositiveSet(rom.RIPEMD160) == false)
-                    return false;
-                if (this.RIPEMD160.MatchesNegativeSet(rom.RIPEMD160) == true)
-                    return false;
-#endif
-
-                // Filter on SHA-1
-                if (this.SHA1.MatchesPositiveSet(rom.SHA1) == false)
-                    return false;
-                if (this.SHA1.MatchesNegativeSet(rom.SHA1) == true)
-                    return false;
-
-                // Filter on SHA-256
-                if (this.SHA256.MatchesPositiveSet(rom.SHA256) == false)
-                    return false;
-                if (this.SHA256.MatchesNegativeSet(rom.SHA256) == true)
-                    return false;
-
-                // Filter on SHA-384
-                if (this.SHA384.MatchesPositiveSet(rom.SHA384) == false)
-                    return false;
-                if (this.SHA384.MatchesNegativeSet(rom.SHA384) == true)
-                    return false;
-
-                // Filter on SHA-512
-                if (this.SHA512.MatchesPositiveSet(rom.SHA512) == false)
-                    return false;
-                if (this.SHA512.MatchesNegativeSet(rom.SHA512) == true)
-                    return false;
-            }
-            else if (item.ItemType == ItemType.Disk)
-            {
-                Disk rom = (Disk)item;
-
-                // Filter on status
-                if (this.ItemStatuses.MatchesPositive(ItemStatus.NULL, rom.ItemStatus) == false)
-                    return false;
-                if (this.ItemStatuses.MatchesNegative(ItemStatus.NULL, rom.ItemStatus) == true)
-                    return false;
-
-                // Filter on MD5
-                if (this.MD5.MatchesPositiveSet(rom.MD5) == false)
-                    return false;
-                if (this.MD5.MatchesNegativeSet(rom.MD5) == true)
-                    return false;
-
-#if NET_FRAMEWORK
-                // Filter on RIPEMD160
-                if (this.RIPEMD160.MatchesPositiveSet(rom.RIPEMD160) == false)
-                    return false;
-                if (this.RIPEMD160.MatchesNegativeSet(rom.RIPEMD160) == true)
-                    return false;
-#endif
-
-                // Filter on SHA-1
-                if (this.SHA1.MatchesPositiveSet(rom.SHA1) == false)
-                    return false;
-                if (this.SHA1.MatchesNegativeSet(rom.SHA1) == true)
-                    return false;
-
-                // Filter on SHA-256
-                if (this.SHA256.MatchesPositiveSet(rom.SHA256) == false)
-                    return false;
-                if (this.SHA256.MatchesNegativeSet(rom.SHA256) == true)
-                    return false;
-
-                // Filter on SHA-384
-                if (this.SHA384.MatchesPositiveSet(rom.SHA384) == false)
-                    return false;
-                if (this.SHA384.MatchesNegativeSet(rom.SHA384) == true)
-                    return false;
-
-                // Filter on SHA-512
-                if (this.SHA512.MatchesPositiveSet(rom.SHA512) == false)
-                    return false;
-                if (this.SHA512.MatchesNegativeSet(rom.SHA512) == true)
-                    return false;
-            }
+            #region Machine Filters
 
             // Filter on machine name
             bool? machineNameFound = this.MachineName.MatchesPositiveSet(item.MachineName);
@@ -598,17 +706,95 @@ namespace SabreTools.Library.DatFiles
             if (machineNameFound == false)
                 return false;
 
+            // Filter on comment
+            if (this.Comment.MatchesPositiveSet(item.Comment) == false)
+                return false;
+            if (this.Comment.MatchesNegativeSet(item.Comment) == true)
+                return false;
+
             // Filter on machine description
             if (this.MachineDescription.MatchesPositiveSet(item.MachineDescription) == false)
                 return false;
             if (this.MachineDescription.MatchesNegativeSet(item.MachineDescription) == true)
                 return false;
 
-            // Filter on item name
-            if (this.ItemName.MatchesPositiveSet(item.Name) == false)
+            // Filter on year
+            if (this.Year.MatchesPositiveSet(item.Year) == false)
                 return false;
-            if (this.ItemName.MatchesNegativeSet(item.Name) == true)
+            if (this.Year.MatchesNegativeSet(item.Year) == true)
                 return false;
+
+            // Filter on manufacturer
+            if (this.Manufacturer.MatchesPositiveSet(item.Manufacturer) == false)
+                return false;
+            if (this.Manufacturer.MatchesNegativeSet(item.Manufacturer) == true)
+                return false;
+
+            // Filter on publisher
+            if (this.Publisher.MatchesPositiveSet(item.Publisher) == false)
+                return false;
+            if (this.Publisher.MatchesNegativeSet(item.Publisher) == true)
+                return false;
+
+            // Filter on category
+            if (this.Category.MatchesPositiveSet(item.Category) == false)
+                return false;
+            if (this.Category.MatchesNegativeSet(item.Category) == true)
+                return false;
+
+            // Filter on romof
+            if (this.RomOf.MatchesPositiveSet(item.RomOf) == false)
+                return false;
+            if (this.RomOf.MatchesNegativeSet(item.RomOf) == true)
+                return false;
+
+            // Filter on cloneof
+            if (this.CloneOf.MatchesPositiveSet(item.CloneOf) == false)
+                return false;
+            if (this.CloneOf.MatchesNegativeSet(item.CloneOf) == true)
+                return false;
+
+            // Filter on sampleof
+            if (this.SampleOf.MatchesPositiveSet(item.SampleOf) == false)
+                return false;
+            if (this.SampleOf.MatchesNegativeSet(item.SampleOf) == true)
+                return false;
+
+            // Filter on supported
+            if (this.Supported.MatchesNeutral(null, item.Supported) == false)
+                return false;
+
+            // Filter on source file
+            if (this.SourceFile.MatchesPositiveSet(item.SourceFile) == false)
+                return false;
+            if (this.SourceFile.MatchesNegativeSet(item.SourceFile) == true)
+                return false;
+
+            // Filter on runnable
+            if (this.Runnable.MatchesNeutral(null, item.Runnable) == false)
+                return false;
+
+            // Filter on board
+            if (this.Board.MatchesPositiveSet(item.Board) == false)
+                return false;
+            if (this.Board.MatchesNegativeSet(item.Board) == true)
+                return false;
+
+            // Filter on rebuildto
+            if (this.RebuildTo.MatchesPositiveSet(item.RebuildTo) == false)
+                return false;
+            if (this.RebuildTo.MatchesNegativeSet(item.RebuildTo) == true)
+                return false;
+
+            // Filter on machine type
+            if (this.MachineTypes.MatchesPositive(MachineType.NULL, item.MachineType) == false)
+                return false;
+            if (this.MachineTypes.MatchesNegative(MachineType.NULL, item.MachineType) == true)
+                return false;
+
+            #endregion
+
+            #region DatItem Filters
 
             // Filter on item type
             if (this.ItemTypes.PositiveSet.Count == 0 && this.ItemTypes.NegativeSet.Count == 0
@@ -618,6 +804,268 @@ namespace SabreTools.Library.DatFiles
                 return false;
             if (this.ItemTypes.MatchesNegativeSet(item.ItemType.ToString()) == true)
                 return false;
+
+            // Filter on item name
+            if (this.ItemName.MatchesPositiveSet(item.Name) == false)
+                return false;
+            if (this.ItemName.MatchesNegativeSet(item.Name) == true)
+                return false;
+
+            // Filter on part name
+            if (this.PartName.MatchesPositiveSet(item.PartName) == false)
+                return false;
+            if (this.PartName.MatchesNegativeSet(item.PartName) == true)
+                return false;
+
+            // Filter on part interface
+            if (this.PartInterface.MatchesPositiveSet(item.PartInterface) == false)
+                return false;
+            if (this.PartInterface.MatchesNegativeSet(item.PartInterface) == true)
+                return false;
+
+            // Filter on area name
+            if (this.AreaName.MatchesPositiveSet(item.AreaName) == false)
+                return false;
+            if (this.AreaName.MatchesNegativeSet(item.AreaName) == true)
+                return false;
+
+            // Filter on area size
+            if (this.AreaSize.MatchesNeutral(null, item.AreaSize) == false)
+                return false;
+            else if (this.AreaSize.MatchesPositive(null, item.AreaSize) == false)
+                return false;
+            else if (this.AreaSize.MatchesNegative(null, item.AreaSize) == false)
+                return false;
+
+            // Take care of item-specific differences
+            switch (item.ItemType)
+            {
+                case ItemType.Archive:
+                    // Archive has no special fields
+                    break;
+
+                case ItemType.BiosSet:
+                    BiosSet biosSet = (BiosSet)item;
+
+                    // Filter on description
+                    if (this.Description.MatchesNeutral(null, biosSet.Description) == false)
+                        return false;
+
+                    // Filter on default
+                    if (this.Default.MatchesNeutral(null, biosSet.Default) == false)
+                        return false;
+
+                    break;
+
+                case ItemType.Blank:
+                    // Blank has no special fields
+                    break;
+
+                case ItemType.Disk:
+                    Disk disk = (Disk)item;
+
+                    // Filter on MD5
+                    if (this.MD5.MatchesPositiveSet(disk.MD5) == false)
+                        return false;
+                    if (this.MD5.MatchesNegativeSet(disk.MD5) == true)
+                        return false;
+
+#if NET_FRAMEWORK
+                    // Filter on RIPEMD160
+                    if (this.RIPEMD160.MatchesPositiveSet(disk.RIPEMD160) == false)
+                        return false;
+                    if (this.RIPEMD160.MatchesNegativeSet(disk.RIPEMD160) == true)
+                        return false;
+#endif
+
+                    // Filter on SHA-1
+                    if (this.SHA1.MatchesPositiveSet(disk.SHA1) == false)
+                        return false;
+                    if (this.SHA1.MatchesNegativeSet(disk.SHA1) == true)
+                        return false;
+
+                    // Filter on SHA-256
+                    if (this.SHA256.MatchesPositiveSet(disk.SHA256) == false)
+                        return false;
+                    if (this.SHA256.MatchesNegativeSet(disk.SHA256) == true)
+                        return false;
+
+                    // Filter on SHA-384
+                    if (this.SHA384.MatchesPositiveSet(disk.SHA384) == false)
+                        return false;
+                    if (this.SHA384.MatchesNegativeSet(disk.SHA384) == true)
+                        return false;
+
+                    // Filter on SHA-512
+                    if (this.SHA512.MatchesPositiveSet(disk.SHA512) == false)
+                        return false;
+                    if (this.SHA512.MatchesNegativeSet(disk.SHA512) == true)
+                        return false;
+
+                    // Filter on merge tag
+                    if (this.MergeTag.MatchesPositiveSet(disk.MergeTag) == false)
+                        return false;
+                    if (this.MergeTag.MatchesNegativeSet(disk.MergeTag) == true)
+                        return false;
+
+                    // Filter on region
+                    if (this.Region.MatchesPositiveSet(disk.Region) == false)
+                        return false;
+                    if (this.Region.MatchesNegativeSet(disk.Region) == true)
+                        return false;
+
+                    // Filter on index
+                    if (this.Index.MatchesPositiveSet(disk.Index) == false)
+                        return false;
+                    if (this.Index.MatchesNegativeSet(disk.Index) == true)
+                        return false;
+
+                    // Filter on writable
+                    if (this.Writable.MatchesNeutral(null, disk.Writable) == false)
+                        return false;
+
+                    // Filter on status
+                    if (this.Status.MatchesPositive(ItemStatus.NULL, disk.ItemStatus) == false)
+                        return false;
+                    if (this.Status.MatchesNegative(ItemStatus.NULL, disk.ItemStatus) == true)
+                        return false;
+
+                    // Filter on optional
+                    if (this.Optional.MatchesNeutral(null, disk.Optional) == false)
+                        return false;
+
+                    break;
+
+                case ItemType.Release:
+                    Release release = (Release)item;
+
+                    // Filter on region
+                    if (this.Region.MatchesPositiveSet(release.Region) == false)
+                        return false;
+                    if (this.Region.MatchesNegativeSet(release.Region) == true)
+                        return false;
+
+                    // Filter on language
+                    if (this.Language.MatchesPositiveSet(release.Language) == false)
+                        return false;
+                    if (this.Language.MatchesNegativeSet(release.Language) == true)
+                        return false;
+
+                    // Filter on date
+                    if (this.Date.MatchesPositiveSet(release.Date) == false)
+                        return false;
+                    if (this.Date.MatchesNegativeSet(release.Date) == true)
+                        return false;
+
+                    // Filter on default
+                    if (this.Default.MatchesNeutral(null, release.Default) == false)
+                        return false;
+
+                    break;
+
+                case ItemType.Rom:
+                    Rom rom = (Rom)item;
+
+                    // Filter on bios
+                    if (this.Bios.MatchesPositiveSet(rom.Bios) == false)
+                        return false;
+                    if (this.Bios.MatchesNegativeSet(rom.Bios) == true)
+                        return false;
+
+                    // Filter on rom size
+                    if (this.Size.MatchesNeutral(-1, rom.Size) == false)
+                        return false;
+                    else if (this.Size.MatchesPositive(-1, rom.Size) == false)
+                        return false;
+                    else if (this.Size.MatchesNegative(-1, rom.Size) == false)
+                        return false;
+
+                    // Filter on CRC
+                    if (this.CRC.MatchesPositiveSet(rom.CRC) == false)
+                        return false;
+                    if (this.CRC.MatchesNegativeSet(rom.CRC) == true)
+                        return false;
+
+                    // Filter on MD5
+                    if (this.MD5.MatchesPositiveSet(rom.MD5) == false)
+                        return false;
+                    if (this.MD5.MatchesNegativeSet(rom.MD5) == true)
+                        return false;
+
+#if NET_FRAMEWORK
+                    // Filter on RIPEMD160
+                    if (this.RIPEMD160.MatchesPositiveSet(rom.RIPEMD160) == false)
+                        return false;
+                    if (this.RIPEMD160.MatchesNegativeSet(rom.RIPEMD160) == true)
+                        return false;
+#endif
+
+                    // Filter on SHA-1
+                    if (this.SHA1.MatchesPositiveSet(rom.SHA1) == false)
+                        return false;
+                    if (this.SHA1.MatchesNegativeSet(rom.SHA1) == true)
+                        return false;
+
+                    // Filter on SHA-256
+                    if (this.SHA256.MatchesPositiveSet(rom.SHA256) == false)
+                        return false;
+                    if (this.SHA256.MatchesNegativeSet(rom.SHA256) == true)
+                        return false;
+
+                    // Filter on SHA-384
+                    if (this.SHA384.MatchesPositiveSet(rom.SHA384) == false)
+                        return false;
+                    if (this.SHA384.MatchesNegativeSet(rom.SHA384) == true)
+                        return false;
+
+                    // Filter on SHA-512
+                    if (this.SHA512.MatchesPositiveSet(rom.SHA512) == false)
+                        return false;
+                    if (this.SHA512.MatchesNegativeSet(rom.SHA512) == true)
+                        return false;
+
+                    // Filter on merge tag
+                    if (this.MergeTag.MatchesPositiveSet(rom.MergeTag) == false)
+                        return false;
+                    if (this.MergeTag.MatchesNegativeSet(rom.MergeTag) == true)
+                        return false;
+
+                    // Filter on region
+                    if (this.Region.MatchesPositiveSet(rom.Region) == false)
+                        return false;
+                    if (this.Region.MatchesNegativeSet(rom.Region) == true)
+                        return false;
+
+                    // Filter on offset
+                    if (this.Offset.MatchesPositiveSet(rom.Offset) == false)
+                        return false;
+                    if (this.Offset.MatchesNegativeSet(rom.Offset) == true)
+                        return false;
+
+                    // Filter on date
+                    if (this.Date.MatchesPositiveSet(rom.Date) == false)
+                        return false;
+                    if (this.Date.MatchesNegativeSet(rom.Date) == true)
+                        return false;
+
+                    // Filter on status
+                    if (this.Status.MatchesPositive(ItemStatus.NULL, rom.ItemStatus) == false)
+                        return false;
+                    if (this.Status.MatchesNegative(ItemStatus.NULL, rom.ItemStatus) == true)
+                        return false;
+
+                    // Filter on optional
+                    if (this.Optional.MatchesNeutral(null, rom.Optional) == false)
+                        return false;
+
+                    break;
+
+                case ItemType.Sample:
+                    // Sample has no special fields
+                    break;
+            }
+
+            #endregion
 
             return true;
         }
@@ -824,7 +1272,7 @@ namespace SabreTools.Library.DatFiles
                     continue;
 
                 // If the game (is/is not) a bios, we want to continue
-                if (dev ^ (datFile[game][0].MachineType.HasFlag(MachineType.Device)))
+                if (dev ^ (datFile[game][0].MachineType.HasFlag(Data.MachineType.Device)))
                     continue;
 
                 // If the game has no devices, we continue
@@ -986,14 +1434,14 @@ namespace SabreTools.Library.DatFiles
                 foreach (DatItem item in items)
                 {
                     // If the disk doesn't have a valid merge tag OR the merged file doesn't exist in the parent, then add it
-                    if (item.ItemType == ItemType.Disk && (((Disk)item).MergeTag == null || !datFile[parent].Select(i => i.Name).Contains(((Disk)item).MergeTag)))
+                    if (item.ItemType == Data.ItemType.Disk && (((Disk)item).MergeTag == null || !datFile[parent].Select(i => i.Name).Contains(((Disk)item).MergeTag)))
                     {
                         item.CopyMachineInformation(copyFrom);
                         datFile.Add(parent, item);
                     }
 
                     // Otherwise, if the parent doesn't already contain the non-disk (or a merge-equivalent), add it
-                    else if (item.ItemType != ItemType.Disk && !datFile[parent].Contains(item))
+                    else if (item.ItemType != Data.ItemType.Disk && !datFile[parent].Contains(item))
                     {
                         // Rename the child so it's in a subfolder
                         item.Name = $"{item.MachineName}\\{item.Name}";
@@ -1021,8 +1469,8 @@ namespace SabreTools.Library.DatFiles
             foreach (string game in games)
             {
                 if (datFile[game].Count > 0
-                    && (datFile[game][0].MachineType.HasFlag(MachineType.Bios)
-                        || datFile[game][0].MachineType.HasFlag(MachineType.Device)))
+                    && (datFile[game][0].MachineType.HasFlag(Data.MachineType.Bios)
+                        || datFile[game][0].MachineType.HasFlag(Data.MachineType.Device)))
                 {
                     datFile.Remove(game);
                 }
@@ -1045,7 +1493,7 @@ namespace SabreTools.Library.DatFiles
                     continue;
 
                 // If the game (is/is not) a bios, we want to continue
-                if (bios ^ datFile[game][0].MachineType.HasFlag(MachineType.Bios))
+                if (bios ^ datFile[game][0].MachineType.HasFlag(Data.MachineType.Bios))
                     continue;
 
                 // Determine if the game has a parent or not

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -15,37 +15,144 @@ namespace SabreTools.Library.DatFiles
     /// <summary>
     /// Represents the filtering operations that need to be performed on a set of items, usually a DAT
     /// </summary>
-    /// TODO: Can this use `Field` instead of explicit filters?
     public class Filter
     {
+        #region Private instance variables
+
+        private Dictionary<string, object> Filters { get; set; } = new Dictionary<string, object>()
+        {
+            #region Machine Filters
+
+            { "Machine.Name", new FilterItem<string>() },
+            { "Machine.Comment", new FilterItem<string>() },
+            { "Machine.Description", new FilterItem<string>() },
+            { "Machine.Year", new FilterItem<string>() },
+            { "Machine.Manufacturer", new FilterItem<string>() },
+            { "Machine.Publisher", new FilterItem<string>() },
+            { "Machine.Category", new FilterItem<string>() },
+            { "Machine.RomOf", new FilterItem<string>() },
+            { "Machine.CloneOf", new FilterItem<string>() },
+            { "Machine.SampleOf", new FilterItem<string>() },
+            { "Machine.Supported", new FilterItem<bool?>() { Neutral = null } },
+            { "Machine.SourceFile", new FilterItem<string>() },
+            { "Machine.Runnable", new FilterItem<bool?>() { Neutral = null } },
+            { "Machine.Board", new FilterItem<string>() },
+            { "Machine.RebuildTo", new FilterItem<string>() },
+            { "Machine.Devices", new FilterItem<string>() }, // List<string>
+            { "Machine.SlotOptions", new FilterItem<string>() }, // List<string>
+            { "Machine.Infos", new FilterItem<string>() }, // List<KeyValuePair<string, string>>
+            { "Machine.MachineType", new FilterItem<MachineType>()  { Positive = MachineType.NULL, Negative = MachineType.NULL } },
+
+            { "IncludeOfInGame", new FilterItem<bool>() { Neutral = false } },
+
+            #endregion
+
+            #region DatItem Filters
+
+            { "DatItem.Type", new FilterItem<string>() },
+            { "DatItem.Name", new FilterItem<string>() },
+            { "DatItem.PartName", new FilterItem<string>() },
+            { "DatItem.PartInterface", new FilterItem<string>() },
+            { "DatItem.Features", new FilterItem<string>() }, // List<KeyValuePair<string, string>>
+            { "DatItem.AreaName", new FilterItem<string>() },
+            { "DatItem.AreaSize", new FilterItem<long?>() },
+            { "DatItem.Default", new FilterItem<bool?>() { Neutral = null } },
+            { "DatItem.Description", new FilterItem<string>() },
+            { "DatItem.Size", new FilterItem<long>() { Positive = -1, Negative = -1, Neutral = -1 } },
+            { "DatItem.CRC", new FilterItem<string>() },
+            { "DatItem.MD5", new FilterItem<string>() },
+#if NET_FRAMEWORK
+            { "DatItem.RIPEMD160", new FilterItem<string>() },
+#endif
+            { "DatItem.SHA1", new FilterItem<string>() },
+            { "DatItem.SHA256", new FilterItem<string>() },
+            { "DatItem.SHA384", new FilterItem<string>() },
+            { "DatItem.SHA512", new FilterItem<string>() },
+            { "DatItem.Merge", new FilterItem<string>() },
+            { "DatItem.Region", new FilterItem<string>() },
+            { "DatItem.Index", new FilterItem<string>() },
+            { "DatItem.Writable", new FilterItem<bool?>() { Neutral = null } },
+            { "DatItem.Optional", new FilterItem<bool?>() { Neutral = null } },
+            { "DatItem.Status", new FilterItem<ItemStatus>() { Positive = ItemStatus.NULL, Negative = ItemStatus.NULL } },
+            { "DatItem.Language", new FilterItem<string>() },
+            { "DatItem.Date", new FilterItem<string>() },
+            { "DatItem.Bios", new FilterItem<string>() },
+            { "DatItem.Offset", new FilterItem<string>() },
+
+            #endregion
+
+            #region Manipulation Filters
+
+            { "Clean", new FilterItem<bool>() { Neutral = false } },
+            { "DescriptionAsName", new FilterItem<bool>() { Neutral = false } },
+            { "InternalSplit", new FilterItem<SplitType>() { Neutral = SplitType.None } },
+            { "RemoveUnicode", new FilterItem<bool>() { Neutral = false } },
+            { "Root", new FilterItem<string>() { Neutral = null } },
+            { "Single", new FilterItem<bool>() { Neutral = false } },
+            { "Trim", new FilterItem<bool>() { Neutral = false } },
+
+            #endregion
+        };
+
+        #endregion
+
         #region Pubically facing variables
 
         #region Machine Filters
 
         /// <summary>
+        /// Include or exclude categories
+        /// </summary>
+        public FilterItem<string> Category
+        {
+            get { return Filters["Machine.Category"] as FilterItem<string>; }
+            set { Filters["Machine.Category"] = value; }
+        }
+
+        /// <summary>
         /// Include or exclude machine names
         /// </summary>
-        public FilterItem<string> MachineName { get; set; } = new FilterItem<string>();
+        public FilterItem<string> MachineName
+        {
+            get { return Filters["Machine.Name"] as FilterItem<string>; }
+            set { Filters["Machine.Name"] = value; }
+        }
 
         /// <summary>
         /// Include romof and cloneof when filtering machine names
         /// </summary>
-        public FilterItem<bool> IncludeOfInGame { get; set; } = new FilterItem<bool>() { Neutral = false };
+        public FilterItem<bool> IncludeOfInGame
+        {
+            get { return Filters["IncludeOfInGame"] as FilterItem<bool>; }
+            set { Filters["IncludeOfInGame"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude machine descriptions
         /// </summary>
-        public FilterItem<string> MachineDescription { get; set; } = new FilterItem<string>();
+        public FilterItem<string> MachineDescription
+        {
+            get { return Filters["Machine.Description"] as FilterItem<string>; }
+            set { Filters["Machine.Description"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude machine types
         /// </summary>
-        public FilterItem<MachineType> MachineTypes { get; set; } = new FilterItem<MachineType>() { Positive = MachineType.NULL, Negative = MachineType.NULL };
+        public FilterItem<MachineType> MachineTypes
+        {
+            get { return Filters["Machine.MachineType"] as FilterItem<MachineType>; }
+            set { Filters["Machine.MachineType"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude items with the "Runnable" tag
         /// </summary>
-        public FilterItem<bool?> Runnable { get; set; } = new FilterItem<bool?>() { Neutral = null };
+        public FilterItem<bool?> Runnable
+        {
+            get { return Filters["Machine.Runnable"] as FilterItem<bool?>; }
+            set { Filters["Machine.Runnable"] = value; }
+        }
 
         #endregion
 
@@ -54,60 +161,104 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude item names
         /// </summary>
-        public FilterItem<string> ItemName { get; set; } = new FilterItem<string>();
+        public FilterItem<string> ItemName
+        {
+            get { return Filters["DatItem.Name"] as FilterItem<string>; }
+            set { Filters["DatItem.Name"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude item types
         /// </summary>
-        public FilterItem<string> ItemTypes { get; set; } = new FilterItem<string>();
+        public FilterItem<string> ItemTypes
+        {
+            get { return Filters["DatItem.Type"] as FilterItem<string>; }
+            set { Filters["DatItem.Type"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude item sizes
         /// </summary>
         /// <remarks>Positive means "Greater than or equal", Negative means "Less than or equal", Neutral means "Equal"</remarks>
-        public FilterItem<long> Size { get; set; } = new FilterItem<long>() { Positive = -1, Negative = -1, Neutral = -1 };
+        public FilterItem<long> Size
+        {
+            get { return Filters["DatItem.Size"] as FilterItem<long>; }
+            set { Filters["DatItem.Size"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude CRC32 hashes
         /// </summary>
-        public FilterItem<string> CRC { get; set; } = new FilterItem<string>();
+        public FilterItem<string> CRC
+        {
+            get { return Filters["DatItem.CRC"] as FilterItem<string>; }
+            set { Filters["DatItem.CRC"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude MD5 hashes
         /// </summary>
-        public FilterItem<string> MD5 { get; set; } = new FilterItem<string>();
+        public FilterItem<string> MD5
+        {
+            get { return Filters["DatItem.MD5"] as FilterItem<string>; }
+            set { Filters["DatItem.MD5"] = value; }
+        }
 
 #if NET_FRAMEWORK
         /// <summary>
         /// Include or exclude RIPEMD160 hashes
         /// </summary>
-        public FilterItem<string> RIPEMD160 { get; set; } = new FilterItem<string>();
+        public FilterItem<string> RIPEMD160
+        {
+            get { return Filters["DatItem.RIPEMD160"] as FilterItem<string>; }
+            set { Filters["DatItem.RIPEMD160"] = value; }
+        }
 #endif
 
         /// <summary>
         /// Include or exclude SHA-1 hashes
         /// </summary>
-        public FilterItem<string> SHA1 { get; set; } = new FilterItem<string>();
+        public FilterItem<string> SHA1
+        {
+            get { return Filters["DatItem.SHA1"] as FilterItem<string>; }
+            set { Filters["DatItem.SHA1"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude SHA-256 hashes
         /// </summary>
-        public FilterItem<string> SHA256 { get; set; } = new FilterItem<string>();
+        public FilterItem<string> SHA256
+        {
+            get { return Filters["DatItem.SHA256"] as FilterItem<string>; }
+            set { Filters["DatItem.SHA256"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude SHA-384 hashes
         /// </summary>
-        public FilterItem<string> SHA384 { get; set; } = new FilterItem<string>();
+        public FilterItem<string> SHA384
+        {
+            get { return Filters["DatItem.SHA384"] as FilterItem<string>; }
+            set { Filters["DatItem.SHA384"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude SHA-512 hashes
         /// </summary>
-        public FilterItem<string> SHA512 { get; set; } = new FilterItem<string>();
+        public FilterItem<string> SHA512
+        {
+            get { return Filters["DatItem.SHA512"] as FilterItem<string>; }
+            set { Filters["DatItem.SHA512"] = value; }
+        }
 
         /// <summary>
         /// Include or exclude item statuses
         /// </summary>
-        public FilterItem<ItemStatus> ItemStatuses { get; set; } = new FilterItem<ItemStatus>() { Positive = ItemStatus.NULL, Negative = ItemStatus.NULL };
+        public FilterItem<ItemStatus> ItemStatuses
+        {
+            get { return Filters["DatItem.Status"] as FilterItem<ItemStatus>; }
+            set { Filters["DatItem.Status"] = value; }
+        }
 
         #endregion
 
@@ -116,37 +267,65 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Clean all names to WoD standards
         /// </summary>
-        public FilterItem<bool> Clean { get; set; } = new FilterItem<bool>() { Neutral = false };
+        public FilterItem<bool> Clean
+        {
+            get { return Filters["Clean"] as FilterItem<bool>; }
+            set { Filters["Clean"] = value; }
+        }
 
         /// <summary>
         /// Set Machine Description from Machine Name
         /// </summary>
-        public FilterItem<bool> DescriptionAsName { get; set; } = new FilterItem<bool>() { Neutral = false };
+        public FilterItem<bool> DescriptionAsName
+        {
+            get { return Filters["DescriptionAsName"] as FilterItem<bool>; }
+            set { Filters["DescriptionAsName"] = value; }
+        }
 
         /// <summary>
         /// Internally split a DatFile
         /// </summary>
-        public FilterItem<SplitType> InternalSplit { get; set; } = new FilterItem<SplitType>() { Neutral = SplitType.None };
+        public FilterItem<SplitType> InternalSplit
+        {
+            get { return Filters["InternalSplit"] as FilterItem<SplitType>; }
+            set { Filters["InternalSplit"] = value; }
+        }
 
         /// <summary>
         /// Remove all unicode characters
         /// </summary>
-        public FilterItem<bool> RemoveUnicode { get; set; } = new FilterItem<bool>() { Neutral = false };
-
-        /// <summary>
-        /// Change all machine names to "!"
-        /// </summary>
-        public FilterItem<bool> Single { get; set; } = new FilterItem<bool>() { Neutral = false };
-
-        /// <summary>
-        /// Trim total machine and item name to not exceed NTFS limits
-        /// </summary>
-        public FilterItem<bool> Trim { get; set; } = new FilterItem<bool>() { Neutral = false };
+        public FilterItem<bool> RemoveUnicode
+        {
+            get { return Filters["RemoveUnicode"] as FilterItem<bool>; }
+            set { Filters["RemoveUnicode"] = value; }
+        }
 
         /// <summary>
         /// Include root directory when determing trim sizes
         /// </summary>
-        public FilterItem<string> Root { get; set; } = new FilterItem<string>() { Neutral = null };
+        public FilterItem<string> Root
+        {
+            get { return Filters["Root"] as FilterItem<string>; }
+            set { Filters["Root"] = value; }
+        }
+
+        /// <summary>
+        /// Change all machine names to "!"
+        /// </summary>
+        public FilterItem<bool> Single
+        {
+            get { return Filters["Single"] as FilterItem<bool>; }
+            set { Filters["Single"] = value; }
+        }
+
+        /// <summary>
+        /// Trim total machine and item name to not exceed NTFS limits
+        /// </summary>
+        public FilterItem<bool> Trim
+        {
+            get { return Filters["Trim"] as FilterItem<bool>; }
+            set { Filters["Trim"] = value; }
+        }
 
         #endregion
 
@@ -276,6 +455,12 @@ namespace SabreTools.Library.DatFiles
             if (this.MachineTypes.MatchesPositive(MachineType.NULL, item.MachineType) == false)
                 return false;
             if (this.MachineTypes.MatchesNegative(MachineType.NULL, item.MachineType) == true)
+                return false;
+
+            // Filter on machine category
+            if (this.Category.MatchesPositiveSet(item.Category) == false)
+                return false;
+            if (this.Category.MatchesNegativeSet(item.Category) == true)
                 return false;
 
             // Filter on machine runability

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -80,16 +80,12 @@ namespace SabreTools.Library.DatFiles
             #endregion
         };
 
-        #endregion
-
-        #region Pubically facing variables
-
         #region Machine Filters
 
         /// <summary>
         /// Include or exclude machine names
         /// </summary>
-        public FilterItem<string> MachineName
+        private FilterItem<string> MachineName
         {
             get { return Filters["Machine.Name"] as FilterItem<string>; }
             set { Filters["Machine.Name"] = value; }
@@ -98,7 +94,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine comments
         /// </summary>
-        public FilterItem<string> Comment
+        private FilterItem<string> Comment
         {
             get { return Filters["Machine.Comment"] as FilterItem<string>; }
             set { Filters["Machine.Comment"] = value; }
@@ -107,7 +103,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine descriptions
         /// </summary>
-        public FilterItem<string> MachineDescription
+        private FilterItem<string> MachineDescription
         {
             get { return Filters["Machine.Description"] as FilterItem<string>; }
             set { Filters["Machine.Description"] = value; }
@@ -116,7 +112,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine years
         /// </summary>
-        public FilterItem<string> Year
+        private FilterItem<string> Year
         {
             get { return Filters["Machine.Year"] as FilterItem<string>; }
             set { Filters["Machine.Year"] = value; }
@@ -125,7 +121,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine manufacturers
         /// </summary>
-        public FilterItem<string> Manufacturer
+        private FilterItem<string> Manufacturer
         {
             get { return Filters["Machine.Manufacturer"] as FilterItem<string>; }
             set { Filters["Machine.Manufacturer"] = value; }
@@ -134,7 +130,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine publishers
         /// </summary>
-        public FilterItem<string> Publisher
+        private FilterItem<string> Publisher
         {
             get { return Filters["Machine.Publisher"] as FilterItem<string>; }
             set { Filters["Machine.Publisher"] = value; }
@@ -143,7 +139,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine categories
         /// </summary>
-        public FilterItem<string> Category
+        private FilterItem<string> Category
         {
             get { return Filters["Machine.Category"] as FilterItem<string>; }
             set { Filters["Machine.Category"] = value; }
@@ -152,7 +148,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine romof
         /// </summary>
-        public FilterItem<string> RomOf
+        private FilterItem<string> RomOf
         {
             get { return Filters["Machine.RomOf"] as FilterItem<string>; }
             set { Filters["Machine.RomOf"] = value; }
@@ -161,7 +157,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine cloneof
         /// </summary>
-        public FilterItem<string> CloneOf
+        private FilterItem<string> CloneOf
         {
             get { return Filters["Machine.CloneOf"] as FilterItem<string>; }
             set { Filters["Machine.CloneOf"] = value; }
@@ -170,7 +166,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine sampleof
         /// </summary>
-        public FilterItem<string> SampleOf
+        private FilterItem<string> SampleOf
         {
             get { return Filters["Machine.SampleOf"] as FilterItem<string>; }
             set { Filters["Machine.SampleOf"] = value; }
@@ -179,7 +175,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude items with the "Supported" tag
         /// </summary>
-        public FilterItem<bool?> Supported
+        private FilterItem<bool?> Supported
         {
             get { return Filters["Machine.Supported"] as FilterItem<bool?>; }
             set { Filters["Machine.Supported"] = value; }
@@ -188,7 +184,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine source file
         /// </summary>
-        public FilterItem<string> SourceFile
+        private FilterItem<string> SourceFile
         {
             get { return Filters["Machine.SourceFile"] as FilterItem<string>; }
             set { Filters["Machine.SourceFile"] = value; }
@@ -197,7 +193,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude items with the "Runnable" tag
         /// </summary>
-        public FilterItem<bool?> Runnable
+        private FilterItem<bool?> Runnable
         {
             get { return Filters["Machine.Runnable"] as FilterItem<bool?>; }
             set { Filters["Machine.Runnable"] = value; }
@@ -206,7 +202,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine board
         /// </summary>
-        public FilterItem<string> Board
+        private FilterItem<string> Board
         {
             get { return Filters["Machine.Board"] as FilterItem<string>; }
             set { Filters["Machine.Board"] = value; }
@@ -215,7 +211,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine rebuildto
         /// </summary>
-        public FilterItem<string> RebuildTo
+        private FilterItem<string> RebuildTo
         {
             get { return Filters["Machine.RebuildTo"] as FilterItem<string>; }
             set { Filters["Machine.RebuildTo"] = value; }
@@ -224,7 +220,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude machine types
         /// </summary>
-        public FilterItem<MachineType> MachineTypes
+        private FilterItem<MachineType> MachineTypes
         {
             get { return Filters["Machine.MachineType"] as FilterItem<MachineType>; }
             set { Filters["Machine.MachineType"] = value; }
@@ -237,7 +233,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude item types
         /// </summary>
-        public FilterItem<string> ItemTypes
+        private FilterItem<string> ItemTypes
         {
             get { return Filters["DatItem.Type"] as FilterItem<string>; }
             set { Filters["DatItem.Type"] = value; }
@@ -246,7 +242,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude item names
         /// </summary>
-        public FilterItem<string> ItemName
+        private FilterItem<string> ItemName
         {
             get { return Filters["DatItem.Name"] as FilterItem<string>; }
             set { Filters["DatItem.Name"] = value; }
@@ -255,7 +251,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude part names
         /// </summary>
-        public FilterItem<string> PartName
+        private FilterItem<string> PartName
         {
             get { return Filters["DatItem.PartName"] as FilterItem<string>; }
             set { Filters["DatItem.PartName"] = value; }
@@ -264,7 +260,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude part interfaces
         /// </summary>
-        public FilterItem<string> PartInterface
+        private FilterItem<string> PartInterface
         {
             get { return Filters["DatItem.PartInterface"] as FilterItem<string>; }
             set { Filters["DatItem.PartInterface"] = value; }
@@ -273,7 +269,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude area names
         /// </summary>
-        public FilterItem<string> AreaName
+        private FilterItem<string> AreaName
         {
             get { return Filters["DatItem.AreaName"] as FilterItem<string>; }
             set { Filters["DatItem.AreaName"] = value; }
@@ -282,7 +278,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude area sizes
         /// </summary>
-        public FilterItem<long?> AreaSize
+        private FilterItem<long?> AreaSize
         {
             get { return Filters["DatItem.AreaSize"] as FilterItem<long?>; }
             set { Filters["DatItem.AreaSize"] = value; }
@@ -291,7 +287,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude items with the "Default" tag
         /// </summary>
-        public FilterItem<bool?> Default
+        private FilterItem<bool?> Default
         {
             get { return Filters["DatItem.Default"] as FilterItem<bool?>; }
             set { Filters["DatItem.Default"] = value; }
@@ -300,7 +296,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude descriptions
         /// </summary>
-        public FilterItem<string> Description
+        private FilterItem<string> Description
         {
             get { return Filters["DatItem.Description"] as FilterItem<string>; }
             set { Filters["DatItem.Description"] = value; }
@@ -310,7 +306,7 @@ namespace SabreTools.Library.DatFiles
         /// Include or exclude item sizes
         /// </summary>
         /// <remarks>Positive means "Greater than or equal", Negative means "Less than or equal", Neutral means "Equal"</remarks>
-        public FilterItem<long> Size
+        private FilterItem<long> Size
         {
             get { return Filters["DatItem.Size"] as FilterItem<long>; }
             set { Filters["DatItem.Size"] = value; }
@@ -319,7 +315,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude CRC32 hashes
         /// </summary>
-        public FilterItem<string> CRC
+        private FilterItem<string> CRC
         {
             get { return Filters["DatItem.CRC"] as FilterItem<string>; }
             set { Filters["DatItem.CRC"] = value; }
@@ -328,7 +324,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude MD5 hashes
         /// </summary>
-        public FilterItem<string> MD5
+        private FilterItem<string> MD5
         {
             get { return Filters["DatItem.MD5"] as FilterItem<string>; }
             set { Filters["DatItem.MD5"] = value; }
@@ -338,7 +334,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude RIPEMD160 hashes
         /// </summary>
-        public FilterItem<string> RIPEMD160
+        private FilterItem<string> RIPEMD160
         {
             get { return Filters["DatItem.RIPEMD160"] as FilterItem<string>; }
             set { Filters["DatItem.RIPEMD160"] = value; }
@@ -348,7 +344,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude SHA-1 hashes
         /// </summary>
-        public FilterItem<string> SHA1
+        private FilterItem<string> SHA1
         {
             get { return Filters["DatItem.SHA1"] as FilterItem<string>; }
             set { Filters["DatItem.SHA1"] = value; }
@@ -357,7 +353,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude SHA-256 hashes
         /// </summary>
-        public FilterItem<string> SHA256
+        private FilterItem<string> SHA256
         {
             get { return Filters["DatItem.SHA256"] as FilterItem<string>; }
             set { Filters["DatItem.SHA256"] = value; }
@@ -366,7 +362,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude SHA-384 hashes
         /// </summary>
-        public FilterItem<string> SHA384
+        private FilterItem<string> SHA384
         {
             get { return Filters["DatItem.SHA384"] as FilterItem<string>; }
             set { Filters["DatItem.SHA384"] = value; }
@@ -375,7 +371,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude SHA-512 hashes
         /// </summary>
-        public FilterItem<string> SHA512
+        private FilterItem<string> SHA512
         {
             get { return Filters["DatItem.SHA512"] as FilterItem<string>; }
             set { Filters["DatItem.SHA512"] = value; }
@@ -384,7 +380,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude merge tags
         /// </summary>
-        public FilterItem<string> MergeTag
+        private FilterItem<string> MergeTag
         {
             get { return Filters["DatItem.Merge"] as FilterItem<string>; }
             set { Filters["DatItem.Merge"] = value; }
@@ -393,7 +389,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude regions
         /// </summary>
-        public FilterItem<string> Region
+        private FilterItem<string> Region
         {
             get { return Filters["DatItem.Region"] as FilterItem<string>; }
             set { Filters["DatItem.Region"] = value; }
@@ -402,7 +398,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude indexes
         /// </summary>
-        public FilterItem<string> Index
+        private FilterItem<string> Index
         {
             get { return Filters["DatItem.Index"] as FilterItem<string>; }
             set { Filters["DatItem.Index"] = value; }
@@ -411,7 +407,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude items with the "Writable" tag
         /// </summary>
-        public FilterItem<bool?> Writable
+        private FilterItem<bool?> Writable
         {
             get { return Filters["DatItem.Writable"] as FilterItem<bool?>; }
             set { Filters["DatItem.Writable"] = value; }
@@ -420,7 +416,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude items with the "Writable" tag
         /// </summary>
-        public FilterItem<bool?> Optional
+        private FilterItem<bool?> Optional
         {
             get { return Filters["DatItem.Optional"] as FilterItem<bool?>; }
             set { Filters["DatItem.Optional"] = value; }
@@ -429,7 +425,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude item statuses
         /// </summary>
-        public FilterItem<ItemStatus> Status
+        private FilterItem<ItemStatus> Status
         {
             get { return Filters["DatItem.Status"] as FilterItem<ItemStatus>; }
             set { Filters["DatItem.Status"] = value; }
@@ -438,7 +434,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude languages
         /// </summary>
-        public FilterItem<string> Language
+        private FilterItem<string> Language
         {
             get { return Filters["DatItem.Language"] as FilterItem<string>; }
             set { Filters["DatItem.Language"] = value; }
@@ -447,7 +443,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude dates
         /// </summary>
-        public FilterItem<string> Date
+        private FilterItem<string> Date
         {
             get { return Filters["DatItem.Date"] as FilterItem<string>; }
             set { Filters["DatItem.Date"] = value; }
@@ -456,7 +452,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude bioses
         /// </summary>
-        public FilterItem<string> Bios
+        private FilterItem<string> Bios
         {
             get { return Filters["DatItem.Bios"] as FilterItem<string>; }
             set { Filters["DatItem.Bios"] = value; }
@@ -465,7 +461,7 @@ namespace SabreTools.Library.DatFiles
         /// <summary>
         /// Include or exclude offsets
         /// </summary>
-        public FilterItem<string> Offset
+        private FilterItem<string> Offset
         {
             get { return Filters["DatItem.Offset"] as FilterItem<string>; }
             set { Filters["DatItem.Offset"] = value; }
@@ -473,7 +469,10 @@ namespace SabreTools.Library.DatFiles
 
         #endregion
 
-        // TODO: Should these actually be FilterItems? It seems needless
+        #endregion // Private instance variables
+
+        #region Pubically facing variables
+
         #region Manipulation Flags
 
         /// <summary>

--- a/SabreTools.Library/DatFiles/Filter.cs
+++ b/SabreTools.Library/DatFiles/Filter.cs
@@ -80,6 +80,7 @@ namespace SabreTools.Library.DatFiles
             #endregion
         };
 
+        // TODO: Can these explicit vars be removed eventually?
         #region Machine Filters
 
         /// <summary>
@@ -228,6 +229,7 @@ namespace SabreTools.Library.DatFiles
 
         #endregion
 
+        // TODO: Can these explicit vars be removed eventually?
         #region DatItem Filters
 
         /// <summary>
@@ -536,470 +538,481 @@ namespace SabreTools.Library.DatFiles
                 string filterField = filterPairTrimmed.Split(':')[0].ToLowerInvariant().Trim('"', ' ', '\t');
                 string filterValue = filterPairTrimmed.Substring(filterField.Length + 1).Trim('"', ' ', '\t');
 
-                switch (filterField)
-                {
-                    #region Machine Filters
+                SetFilter(filterField, filterValue, negate);
+            }
+        }
 
-                    // Machine.Name
-                    case "game":
-                    case "gamename":
-                    case "machine":
-                    case "machinename":
-                        if (negate)
-                            MachineName.NegativeSet.Add(filterValue);
-                        else
-                            MachineName.PositiveSet.Add(filterValue);
-                        break;
+        /// <summary>
+        /// Set a single filter from key
+        /// </summary>
+        /// <param name="key">Key for the filter to be set</param>
+        /// <param name="value">Value of the filter</param>
+        /// <param name="negate">True if negative filter, false otherwise</param>
+        public void SetFilter(string key, string value, bool negate)
+        {
+            switch (key)
+            {
+                #region Machine Filters
 
-                    // Machine.Comment
-                    case "comment":
-                        if (negate)
-                            Comment.NegativeSet.Add(filterValue);
-                        else
-                            Comment.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Name
+                case "game":
+                case "gamename":
+                case "machine":
+                case "machinename":
+                    if (negate)
+                        MachineName.NegativeSet.Add(value);
+                    else
+                        MachineName.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.Description
-                    case "gamedesc":
-                    case "gamedescription":
-                    case "machinedesc":
-                    case "machinedescription":
-                        if (negate)
-                            MachineDescription.NegativeSet.Add(filterValue);
-                        else
-                            MachineDescription.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Comment
+                case "comment":
+                    if (negate)
+                        Comment.NegativeSet.Add(value);
+                    else
+                        Comment.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.Year
-                    case "year":
-                        if (negate)
-                            Year.NegativeSet.Add(filterValue);
-                        else
-                            Year.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Description
+                case "gamedesc":
+                case "gamedescription":
+                case "machinedesc":
+                case "machinedescription":
+                    if (negate)
+                        MachineDescription.NegativeSet.Add(value);
+                    else
+                        MachineDescription.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.Manufacturer
-                    case "manufacturer":
-                        if (negate)
-                            Manufacturer.NegativeSet.Add(filterValue);
-                        else
-                            Manufacturer.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Year
+                case "year":
+                    if (negate)
+                        Year.NegativeSet.Add(value);
+                    else
+                        Year.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.Publisher
-                    case "publisher":
-                        if (negate)
-                            Publisher.NegativeSet.Add(filterValue);
-                        else
-                            Publisher.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Manufacturer
+                case "manufacturer":
+                    if (negate)
+                        Manufacturer.NegativeSet.Add(value);
+                    else
+                        Manufacturer.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.Category
-                    case "category":
-                        if (negate)
-                            Category.NegativeSet.Add(filterValue);
-                        else
-                            Category.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Publisher
+                case "publisher":
+                    if (negate)
+                        Publisher.NegativeSet.Add(value);
+                    else
+                        Publisher.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.RomOf
-                    case "romof":
-                        if (negate)
-                            RomOf.NegativeSet.Add(filterValue);
-                        else
-                            RomOf.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Category
+                case "category":
+                    if (negate)
+                        Category.NegativeSet.Add(value);
+                    else
+                        Category.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.CloneOf
-                    case "cloneof":
-                        if (negate)
-                            CloneOf.NegativeSet.Add(filterValue);
-                        else
-                            CloneOf.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.RomOf
+                case "romof":
+                    if (negate)
+                        RomOf.NegativeSet.Add(value);
+                    else
+                        RomOf.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.SampleOf
-                    case "sampleof":
-                        if (negate)
-                            SampleOf.NegativeSet.Add(filterValue);
-                        else
-                            SampleOf.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.CloneOf
+                case "cloneof":
+                    if (negate)
+                        CloneOf.NegativeSet.Add(value);
+                    else
+                        CloneOf.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.Supported
-                    case "supported":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            Supported.Neutral = false;
-                        else
-                            Supported.Neutral = true;
-                        break;
+                // Machine.SampleOf
+                case "sampleof":
+                    if (negate)
+                        SampleOf.NegativeSet.Add(value);
+                    else
+                        SampleOf.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.SourceFile
-                    case "source":
-                    case "sourcefile":
-                        if (negate)
-                            SourceFile.NegativeSet.Add(filterValue);
-                        else
-                            SourceFile.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Supported
+                case "supported":
+                    if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
+                        Supported.Neutral = false;
+                    else
+                        Supported.Neutral = true;
+                    break;
 
-                    // Machine.Runnable
-                    case "runnable":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            Runnable.Neutral = false;
-                        else
-                            Runnable.Neutral = true;
-                        break;
+                // Machine.SourceFile
+                case "source":
+                case "sourcefile":
+                    if (negate)
+                        SourceFile.NegativeSet.Add(value);
+                    else
+                        SourceFile.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.Board
-                    case "board":
-                        if (negate)
-                            Board.NegativeSet.Add(filterValue);
-                        else
-                            Board.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Runnable
+                case "runnable":
+                    if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
+                        Runnable.Neutral = false;
+                    else
+                        Runnable.Neutral = true;
+                    break;
 
-                    // Machine.RebuildTo
-                    case "rebuild":
-                    case "rebuildto":
-                        if (negate)
-                            RebuildTo.NegativeSet.Add(filterValue);
-                        else
-                            RebuildTo.PositiveSet.Add(filterValue);
-                        break;
+                // Machine.Board
+                case "board":
+                    if (negate)
+                        Board.NegativeSet.Add(value);
+                    else
+                        Board.PositiveSet.Add(value);
+                    break;
 
-                    // Machine.MachineType
-                    case "gametype":
-                    case "machinetype":
-                        if (negate)
-                            MachineTypes.Negative |= filterValue.AsMachineType();
-                        else
-                            MachineTypes.Positive |= filterValue.AsMachineType();
-                        break;
+                // Machine.RebuildTo
+                case "rebuild":
+                case "rebuildto":
+                    if (negate)
+                        RebuildTo.NegativeSet.Add(value);
+                    else
+                        RebuildTo.PositiveSet.Add(value);
+                    break;
 
-                    #endregion
+                // Machine.MachineType
+                case "gametype":
+                case "machinetype":
+                    if (negate)
+                        MachineTypes.Negative |= value.AsMachineType();
+                    else
+                        MachineTypes.Positive |= value.AsMachineType();
+                    break;
 
-                    #region DatItem Filters
+                #endregion
 
-                    // DatItem.Type
-                    case "itemtype":
-                    case "type":
-                        if (filterValue.AsItemType() == null)
-                            continue;
+                #region DatItem Filters
 
-                        if (negate)
-                            ItemTypes.NegativeSet.Add(filterValue);
-                        else
-                            ItemTypes.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Type
+                case "itemtype":
+                case "type":
+                    if (value.AsItemType() == null)
+                        return;
 
-                    // DatItem.Name
-                    case "item":
-                    case "itemname":
-                        if (negate)
-                            ItemName.NegativeSet.Add(filterValue);
-                        else
-                            ItemName.PositiveSet.Add(filterValue);
-                        break;
+                    if (negate)
+                        ItemTypes.NegativeSet.Add(value);
+                    else
+                        ItemTypes.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.PartName
-                    case "partname":
-                        if (negate)
-                            PartName.NegativeSet.Add(filterValue);
-                        else
-                            PartName.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Name
+                case "item":
+                case "itemname":
+                    if (negate)
+                        ItemName.NegativeSet.Add(value);
+                    else
+                        ItemName.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.PartInterface
-                    case "partinterface":
-                        if (negate)
-                            PartInterface.NegativeSet.Add(filterValue);
-                        else
-                            PartInterface.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.PartName
+                case "partname":
+                    if (negate)
+                        PartName.NegativeSet.Add(value);
+                    else
+                        PartName.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.AreaName
-                    case "areaname":
-                        if (negate)
-                            AreaName.NegativeSet.Add(filterValue);
-                        else
-                            AreaName.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.PartInterface
+                case "partinterface":
+                    if (negate)
+                        PartInterface.NegativeSet.Add(value);
+                    else
+                        PartInterface.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.AreaSize
-                    case "areasize":
-                        bool? asOperation = null;
-                        if (filterValue.StartsWith(">"))
-                            asOperation = true;
-                        else if (filterValue.StartsWith("<"))
-                            asOperation = false;
-                        else if (filterValue.StartsWith("="))
-                            asOperation = null;
+                // DatItem.AreaName
+                case "areaname":
+                    if (negate)
+                        AreaName.NegativeSet.Add(value);
+                    else
+                        AreaName.PositiveSet.Add(value);
+                    break;
 
-                        string areasizeString = filterValue.TrimStart('>', '<', '=');
-                        if (!Int64.TryParse(areasizeString, out long areasize))
-                            continue;
+                // DatItem.AreaSize
+                case "areasize":
+                    bool? asOperation = null;
+                    if (value.StartsWith(">"))
+                        asOperation = true;
+                    else if (value.StartsWith("<"))
+                        asOperation = false;
+                    else if (value.StartsWith("="))
+                        asOperation = null;
 
-                        // Equal
-                        if (asOperation == null && !negate)
-                        {
-                            AreaSize.Neutral = areasize;
-                        }
+                    string areasizeString = value.TrimStart('>', '<', '=');
+                    if (!Int64.TryParse(areasizeString, out long areasize))
+                        return;
 
-                        // Not Equal
-                        else if (asOperation == null && negate)
-                        {
-                            AreaSize.Negative = areasize - 1;
-                            AreaSize.Positive = areasize + 1;
-                        }
+                    // Equal
+                    if (asOperation == null && !negate)
+                    {
+                        AreaSize.Neutral = areasize;
+                    }
 
-                        // Greater Than or Equal
-                        else if (asOperation == true && !negate)
-                        {
-                            AreaSize.Positive = areasize;
-                        }
+                    // Not Equal
+                    else if (asOperation == null && negate)
+                    {
+                        AreaSize.Negative = areasize - 1;
+                        AreaSize.Positive = areasize + 1;
+                    }
 
-                        // Strictly Less Than
-                        else if (asOperation == true && negate)
-                        {
-                            AreaSize.Negative = areasize - 1;
-                        }
+                    // Greater Than or Equal
+                    else if (asOperation == true && !negate)
+                    {
+                        AreaSize.Positive = areasize;
+                    }
 
-                        // Less Than or Equal
-                        else if (asOperation == false && !negate)
-                        {
-                            AreaSize.Negative = areasize;
-                        }
+                    // Strictly Less Than
+                    else if (asOperation == true && negate)
+                    {
+                        AreaSize.Negative = areasize - 1;
+                    }
 
-                        // Strictly Greater Than
-                        else if (asOperation == false && negate)
-                        {
-                            AreaSize.Positive = areasize + 1;
-                        }
+                    // Less Than or Equal
+                    else if (asOperation == false && !negate)
+                    {
+                        AreaSize.Negative = areasize;
+                    }
 
-                        break;
+                    // Strictly Greater Than
+                    else if (asOperation == false && negate)
+                    {
+                        AreaSize.Positive = areasize + 1;
+                    }
 
-                    // DatItem.Default
-                    case "default":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            Default.Neutral = false;
-                        else
-                            Default.Neutral = true;
-                        break;
+                    break;
 
-                    // DatItem.Description
-                    case "biosdesc":
-                    case "biosdescription":
-                    case "description":
-                        if (negate)
-                            Description.NegativeSet.Add(filterValue);
-                        else
-                            Description.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Default
+                case "default":
+                    if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
+                        Default.Neutral = false;
+                    else
+                        Default.Neutral = true;
+                    break;
 
-                    // DatItem.Size
-                    case "itemsize":
-                    case "romsize":
-                    case "size":
-                        bool? sOperation = null;
-                        if (filterValue.StartsWith(">"))
-                            sOperation = true;
-                        else if (filterValue.StartsWith("<"))
-                            sOperation = false;
-                        else if (filterValue.StartsWith("="))
-                            sOperation = null;
+                // DatItem.Description
+                case "biosdesc":
+                case "biosdescription":
+                case "description":
+                    if (negate)
+                        Description.NegativeSet.Add(value);
+                    else
+                        Description.PositiveSet.Add(value);
+                    break;
 
-                        string sizeString = filterValue.TrimStart('>', '<', '=');
-                        if (!Int64.TryParse(sizeString, out long size))
-                            continue;
+                // DatItem.Size
+                case "itemsize":
+                case "romsize":
+                case "size":
+                    bool? sOperation = null;
+                    if (value.StartsWith(">"))
+                        sOperation = true;
+                    else if (value.StartsWith("<"))
+                        sOperation = false;
+                    else if (value.StartsWith("="))
+                        sOperation = null;
 
-                        // Equal
-                        if (sOperation == null && !negate)
-                        {
-                            Size.Neutral = size;
-                        }
+                    string sizeString = value.TrimStart('>', '<', '=');
+                    if (!Int64.TryParse(sizeString, out long size))
+                        return;
 
-                        // Not Equal
-                        else if (sOperation == null && negate)
-                        {
-                            Size.Negative = size - 1;
-                            Size.Positive = size + 1;
-                        }
+                    // Equal
+                    if (sOperation == null && !negate)
+                    {
+                        Size.Neutral = size;
+                    }
 
-                        // Greater Than or Equal
-                        else if (sOperation == true && !negate)
-                        {
-                            Size.Positive = size;
-                        }
+                    // Not Equal
+                    else if (sOperation == null && negate)
+                    {
+                        Size.Negative = size - 1;
+                        Size.Positive = size + 1;
+                    }
 
-                        // Strictly Less Than
-                        else if (sOperation == true && negate)
-                        {
-                            Size.Negative = size - 1;
-                        }
+                    // Greater Than or Equal
+                    else if (sOperation == true && !negate)
+                    {
+                        Size.Positive = size;
+                    }
 
-                        // Less Than or Equal
-                        else if (sOperation == false && !negate)
-                        {
-                            Size.Negative = size;
-                        }
+                    // Strictly Less Than
+                    else if (sOperation == true && negate)
+                    {
+                        Size.Negative = size - 1;
+                    }
 
-                        // Strictly Greater Than
-                        else if (sOperation == false && negate)
-                        {
-                            Size.Positive = size + 1;
-                        }
+                    // Less Than or Equal
+                    else if (sOperation == false && !negate)
+                    {
+                        Size.Negative = size;
+                    }
 
-                        break;
+                    // Strictly Greater Than
+                    else if (sOperation == false && negate)
+                    {
+                        Size.Positive = size + 1;
+                    }
 
-                    // DatItem.CRC
-                    case "crc":
-                    case "crc32":
-                        if (negate)
-                            CRC.NegativeSet.Add(filterValue);
-                        else
-                            CRC.PositiveSet.Add(filterValue);
-                        break;
+                    break;
 
-                    // DatItem.MD5
-                    case "md5":
-                        if (negate)
-                            MD5.NegativeSet.Add(filterValue);
-                        else
-                            MD5.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.CRC
+                case "crc":
+                case "crc32":
+                    if (negate)
+                        CRC.NegativeSet.Add(value);
+                    else
+                        CRC.PositiveSet.Add(value);
+                    break;
+
+                // DatItem.MD5
+                case "md5":
+                    if (negate)
+                        MD5.NegativeSet.Add(value);
+                    else
+                        MD5.PositiveSet.Add(value);
+                    break;
 
 #if NET_FRAMEWORK
-                    // DatItem.RIPEMD160
-                    case "ripemd160":
-                        if (negate)
-                            RIPEMD160.NegativeSet.Add(filterValue);
-                        else
-                            RIPEMD160.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.RIPEMD160
+                case "ripemd160":
+                    if (negate)
+                        RIPEMD160.NegativeSet.Add(value);
+                    else
+                        RIPEMD160.PositiveSet.Add(value);
+                    break;
 #endif
 
-                    // DatItem.SHA1
-                    case "sha1":
-                    case "sha-1":
-                        if (negate)
-                            SHA1.NegativeSet.Add(filterValue);
-                        else
-                            SHA1.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.SHA1
+                case "sha1":
+                case "sha-1":
+                    if (negate)
+                        SHA1.NegativeSet.Add(value);
+                    else
+                        SHA1.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.SHA256
-                    case "sha256":
-                    case "sha-256":
-                        if (negate)
-                            SHA256.NegativeSet.Add(filterValue);
-                        else
-                            SHA256.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.SHA256
+                case "sha256":
+                case "sha-256":
+                    if (negate)
+                        SHA256.NegativeSet.Add(value);
+                    else
+                        SHA256.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.SHA384
-                    case "sha384":
-                    case "sha-384":
-                        if (negate)
-                            SHA384.NegativeSet.Add(filterValue);
-                        else
-                            SHA384.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.SHA384
+                case "sha384":
+                case "sha-384":
+                    if (negate)
+                        SHA384.NegativeSet.Add(value);
+                    else
+                        SHA384.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.SHA512
-                    case "sha512":
-                    case "sha-512":
-                        if (negate)
-                            SHA512.NegativeSet.Add(filterValue);
-                        else
-                            SHA512.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.SHA512
+                case "sha512":
+                case "sha-512":
+                    if (negate)
+                        SHA512.NegativeSet.Add(value);
+                    else
+                        SHA512.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.Merge
-                    case "merge":
-                    case "mergetag":
-                        if (negate)
-                            MergeTag.NegativeSet.Add(filterValue);
-                        else
-                            MergeTag.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Merge
+                case "merge":
+                case "mergetag":
+                    if (negate)
+                        MergeTag.NegativeSet.Add(value);
+                    else
+                        MergeTag.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.Region
-                    case "region":
-                        if (negate)
-                            Region.NegativeSet.Add(filterValue);
-                        else
-                            Region.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Region
+                case "region":
+                    if (negate)
+                        Region.NegativeSet.Add(value);
+                    else
+                        Region.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.Index
-                    case "index":
-                        if (negate)
-                            Index.NegativeSet.Add(filterValue);
-                        else
-                            Index.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Index
+                case "index":
+                    if (negate)
+                        Index.NegativeSet.Add(value);
+                    else
+                        Index.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.Writable
-                    case "writable":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            Writable.Neutral = false;
-                        else
-                            Writable.Neutral = true;
-                        break;
+                // DatItem.Writable
+                case "writable":
+                    if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
+                        Writable.Neutral = false;
+                    else
+                        Writable.Neutral = true;
+                    break;
 
-                    // DatItem.Optional
-                    case "optional":
-                        if (negate || filterValue.Equals("false", StringComparison.OrdinalIgnoreCase))
-                            Optional.Neutral = false;
-                        else
-                            Optional.Neutral = true;
-                        break;
+                // DatItem.Optional
+                case "optional":
+                    if (negate || value.Equals("false", StringComparison.OrdinalIgnoreCase))
+                        Optional.Neutral = false;
+                    else
+                        Optional.Neutral = true;
+                    break;
 
-                    // DatItem.Status
-                    case "itemstatus":
-                    case "status":
-                        if (negate)
-                            Status.Negative |= filterValue.AsItemStatus();
-                        else
-                            Status.Positive |= filterValue.AsItemStatus();
-                        break;
+                // DatItem.Status
+                case "itemstatus":
+                case "status":
+                    if (negate)
+                        Status.Negative |= value.AsItemStatus();
+                    else
+                        Status.Positive |= value.AsItemStatus();
+                    break;
 
-                    // DatItem.Language
-                    case "lang":
-                    case "language":
-                        if (negate)
-                            Language.NegativeSet.Add(filterValue);
-                        else
-                            Language.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Language
+                case "lang":
+                case "language":
+                    if (negate)
+                        Language.NegativeSet.Add(value);
+                    else
+                        Language.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.Date
-                    case "date":
-                        if (negate)
-                            Date.NegativeSet.Add(filterValue);
-                        else
-                            Date.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Date
+                case "date":
+                    if (negate)
+                        Date.NegativeSet.Add(value);
+                    else
+                        Date.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.Bios
-                    case "bios":
-                        if (negate)
-                            Bios.NegativeSet.Add(filterValue);
-                        else
-                            Bios.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Bios
+                case "bios":
+                    if (negate)
+                        Bios.NegativeSet.Add(value);
+                    else
+                        Bios.PositiveSet.Add(value);
+                    break;
 
-                    // DatItem.Offset
-                    case "offset":
-                        if (negate)
-                            Offset.NegativeSet.Add(filterValue);
-                        else
-                            Offset.PositiveSet.Add(filterValue);
-                        break;
+                // DatItem.Offset
+                case "offset":
+                    if (negate)
+                        Offset.NegativeSet.Add(value);
+                    else
+                        Offset.PositiveSet.Add(value);
+                    break;
 
                     #endregion
-                }
             }
         }
 

--- a/SabreTools.Library/DatFiles/Json.cs
+++ b/SabreTools.Library/DatFiles/Json.cs
@@ -317,6 +317,10 @@ namespace SabreTools.Library.DatFiles
                         machine.Publisher = jtr.ReadAsString();
                         break;
 
+                    case "category":
+                        machine.Category = jtr.ReadAsString();
+                        break;
+
                     case "romof":
                         machine.RomOf = jtr.ReadAsString();
                         break;
@@ -1022,6 +1026,11 @@ namespace SabreTools.Library.DatFiles
                 {
                     jtw.WritePropertyName("publisher");
                     jtw.WriteValue(datItem.Publisher);
+                }
+                if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Category, DatHeader.ExcludeFields)))
+                {
+                    jtw.WritePropertyName("category");
+                    jtw.WriteValue(datItem.Category);
                 }
                 if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.RomOf, DatHeader.ExcludeFields)) && !string.Equals(datItem.MachineName, datItem.RomOf, StringComparison.OrdinalIgnoreCase))
                 {

--- a/SabreTools.Library/DatFiles/Listxml.cs
+++ b/SabreTools.Library/DatFiles/Listxml.cs
@@ -716,6 +716,8 @@ namespace SabreTools.Library.DatFiles
                     xtw.WriteElementString("year", datItem.Year);
                 if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Publisher, DatHeader.ExcludeFields)))
                     xtw.WriteElementString("publisher", datItem.Publisher);
+                if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Category, DatHeader.ExcludeFields)))
+                    xtw.WriteElementString("category", datItem.Category);
 
                 if (!DatHeader.ExcludeFields[(int)Field.Infos] && datItem.Infos != null && datItem.Infos.Count > 0)
                 {

--- a/SabreTools.Library/DatFiles/Logiqx.cs
+++ b/SabreTools.Library/DatFiles/Logiqx.cs
@@ -377,6 +377,10 @@ namespace SabreTools.Library.DatFiles
                         machine.Publisher = reader.ReadElementContentAsString();
                         break;
 
+                    case "category": // Not technically supported but used by some legacy DATs
+                        machine.Category = reader.ReadElementContentAsString();
+                        break;
+
                     case "trurip": // This is special metadata unique to TruRip
                         ReadTruRip(reader.ReadSubtree(), machine);
 
@@ -588,7 +592,7 @@ namespace SabreTools.Library.DatFiles
                         break;
 
                     case "genre":
-                        reader.ReadElementContentAsString();
+                        machine.Category = reader.ReadElementContentAsString();
                         break;
 
                     case "subgenre":
@@ -894,6 +898,8 @@ namespace SabreTools.Library.DatFiles
                     xtw.WriteElementString("publisher", datItem.Publisher);
                 if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Manufacturer, DatHeader.ExcludeFields)))
                     xtw.WriteElementString("manufacturer", datItem.Manufacturer);
+                if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Category, DatHeader.ExcludeFields)))
+                    xtw.WriteElementString("category", datItem.Category);
 
                 xtw.Flush();
             }

--- a/SabreTools.Library/DatFiles/SeparatedValue.cs
+++ b/SabreTools.Library/DatFiles/SeparatedValue.cs
@@ -213,6 +213,10 @@ namespace SabreTools.Library.DatFiles
                             machine.Publisher = value;
                             break;
 
+                        case "Machine.Category":
+                            machine.Category = value;
+                            break;
+
                         case "Machine.RomOf":
                             machine.RomOf = value;
                             break;

--- a/SabreTools.Library/DatFiles/SoftwareList.cs
+++ b/SabreTools.Library/DatFiles/SoftwareList.cs
@@ -174,6 +174,10 @@ namespace SabreTools.Library.DatFiles
                         machine.Publisher = reader.ReadElementContentAsString();
                         break;
 
+                    case "category":
+                        machine.Category = reader.ReadElementContentAsString();
+                        break;
+
                     case "info":
                         machine.Infos.Add(new KeyValuePair<string, string>(reader.GetAttribute("name"), reader.GetAttribute("value")));
                         reader.Read();
@@ -717,6 +721,8 @@ namespace SabreTools.Library.DatFiles
                     xtw.WriteElementString("year", datItem.Year);
                 if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Publisher, DatHeader.ExcludeFields)))
                     xtw.WriteElementString("publisher", datItem.Publisher);
+                if (!string.IsNullOrWhiteSpace(datItem.GetField(Field.Category, DatHeader.ExcludeFields)))
+                    xtw.WriteElementString("category", datItem.Category);
 
                 if (!DatHeader.ExcludeFields[(int)Field.Infos] && datItem.Infos != null && datItem.Infos.Count > 0)
                 {

--- a/SabreTools.Library/DatItems/Archive.cs
+++ b/SabreTools.Library/DatItems/Archive.cs
@@ -32,6 +32,7 @@ namespace SabreTools.Library.DatItems
 
                 Supported = this.Supported,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 Infos = this.Infos,
                 PartName = this.PartName,
                 PartInterface = this.PartInterface,

--- a/SabreTools.Library/DatItems/BiosSet.cs
+++ b/SabreTools.Library/DatItems/BiosSet.cs
@@ -49,6 +49,7 @@ namespace SabreTools.Library.DatItems
 
                 Supported = this.Supported,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 Infos = this.Infos,
                 PartName = this.PartName,
                 PartInterface = this.PartInterface,

--- a/SabreTools.Library/DatItems/Blank.cs
+++ b/SabreTools.Library/DatItems/Blank.cs
@@ -32,6 +32,7 @@ namespace SabreTools.Library.DatItems
 
                 Supported = this.Supported,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 Infos = this.Infos,
                 PartName = this.PartName,
                 PartInterface = this.PartInterface,

--- a/SabreTools.Library/DatItems/DatItem.cs
+++ b/SabreTools.Library/DatItems/DatItem.cs
@@ -207,6 +207,32 @@ namespace SabreTools.Library.DatItems
         }
 
         /// <summary>
+        /// Machine category, if available
+        /// </summary>
+        [JsonIgnore]
+        public string Category
+        {
+            get
+            {
+                if (_machine == null)
+                {
+                    _machine = new Machine();
+                }
+
+                return _machine.Category;
+            }
+            set
+            {
+                if (_machine == null)
+                {
+                    _machine = new Machine();
+                }
+
+                _machine.Category = value;
+            }
+        }
+
+        /// <summary>
         /// Machine romof parent
         /// </summary>
         [JsonIgnore]
@@ -632,6 +658,9 @@ namespace SabreTools.Library.DatItems
                     break;
                 case Field.Publisher:
                     fieldValue = this.Publisher;
+                    break;
+                case Field.Category:
+                    fieldValue = this.Category;
                     break;
                 case Field.RomOf:
                     fieldValue = this.RomOf;

--- a/SabreTools.Library/DatItems/Disk.cs
+++ b/SabreTools.Library/DatItems/Disk.cs
@@ -173,6 +173,7 @@ namespace SabreTools.Library.DatItems
 
                 Supported = this.Supported,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 Infos = this.Infos,
                 PartName = this.PartName,
                 PartInterface = this.PartInterface,
@@ -241,6 +242,7 @@ namespace SabreTools.Library.DatItems
                 Year = this.Year,
                 Manufacturer = this.Manufacturer,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 RomOf = this.RomOf,
                 CloneOf = this.CloneOf,
                 SampleOf = this.SampleOf,

--- a/SabreTools.Library/DatItems/Machine.cs
+++ b/SabreTools.Library/DatItems/Machine.cs
@@ -50,6 +50,12 @@ namespace SabreTools.Library.DatItems
         public string Publisher { get; set; }
 
         /// <summary>
+        /// Category, if available
+        /// </summary>
+        [JsonProperty("category")]
+        public string Category { get; set; }
+
+        /// <summary>
         /// fomof parent
         /// </summary>
         [JsonProperty("romof")]
@@ -138,6 +144,7 @@ namespace SabreTools.Library.DatItems
             Year = null;
             Manufacturer = null;
             Publisher = null;
+            Category = null;
             RomOf = null;
             CloneOf = null;
             SampleOf = null;
@@ -165,6 +172,7 @@ namespace SabreTools.Library.DatItems
             Year = null;
             Manufacturer = null;
             Publisher = null;
+            Category = null;
             RomOf = null;
             CloneOf = null;
             SampleOf = null;
@@ -197,6 +205,7 @@ namespace SabreTools.Library.DatItems
                 Year = this.Year,
                 Manufacturer = this.Manufacturer,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 RomOf = this.RomOf,
                 CloneOf = this.CloneOf,
                 SampleOf = this.SampleOf,

--- a/SabreTools.Library/DatItems/Release.cs
+++ b/SabreTools.Library/DatItems/Release.cs
@@ -65,6 +65,7 @@ namespace SabreTools.Library.DatItems
 
                 Supported = this.Supported,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 Infos = this.Infos,
                 PartName = this.PartName,
                 PartInterface = this.PartInterface,

--- a/SabreTools.Library/DatItems/Rom.cs
+++ b/SabreTools.Library/DatItems/Rom.cs
@@ -220,6 +220,7 @@ namespace SabreTools.Library.DatItems
 
                 Supported = this.Supported,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 Infos = this.Infos,
                 PartName = this.PartName,
                 PartInterface = this.PartInterface,

--- a/SabreTools.Library/DatItems/Sample.cs
+++ b/SabreTools.Library/DatItems/Sample.cs
@@ -32,6 +32,7 @@ namespace SabreTools.Library.DatItems
 
                 Supported = this.Supported,
                 Publisher = this.Publisher,
+                Category = this.Category,
                 Infos = this.Infos,
                 PartName = this.PartName,
                 PartInterface = this.PartInterface,

--- a/SabreTools.Library/Data/Enums.cs
+++ b/SabreTools.Library/Data/Enums.cs
@@ -261,7 +261,6 @@
         Game,
     }
 
-
     /// <summary>
     /// Determines the DAT deduplication type
     /// </summary>
@@ -365,6 +364,7 @@
         Year,
         Manufacturer,
         Publisher,
+        Category,
         RomOf,
         CloneOf,
         SampleOf,

--- a/SabreTools.Library/Data/Enums.cs
+++ b/SabreTools.Library/Data/Enums.cs
@@ -350,6 +350,7 @@
         NULL = 0,
 
         // Generic DatItem
+        ItemType,
         Name,
         PartName,
         PartInterface,

--- a/SabreTools.Library/README.1ST
+++ b/SabreTools.Library/README.1ST
@@ -334,6 +334,17 @@ Options:
 		  compare against the input DATs. This flag forces all CHDs to be
 		  treated like regular files.
 
+	  -cat=, --category-filter=		  Filter by category
+		  Include only items with this category in the output. Additionally,
+		  the user can specify an exact match or full C#-style regex for
+		  pattern matching. Multiple instances of this flag are allowed.
+
+	  -ncat=, --not-category=	 Filter by not category
+		  Include only items without this category in the output.
+		  Additionally, the user can specify an exact match or full C#-style
+		  regex for pattern matching. Multiple instances of this flag are
+		  allowed.
+
 	  -gn=, --game-name=		  Filter by game name
 		  Include only items with this game name in the output. Additionally,
 		  the user can specify an exact match or full C#-style regex for
@@ -950,6 +961,7 @@ Options:
 			  - %name% - Replaced with the Rom name
 			  - %manufacturer% - Replaced with game Manufacturer
 			  - %publisher% - Replaced with game Publisher
+			  - %category% - Replaced with game Category
 			  - %crc% - Replaced with the CRC
 			  - %md5% - Replaced with the MD5
 			  - %ripemd160% - Replaced with the RIPEMD160 (.NET Framework 4.8 only)
@@ -1276,6 +1288,17 @@ Options:
 			  second time, this will skip writing it. This can often speed up
 			  the output process. [Both diff-cascade and diff-reverse-cascade]
 
+	  -cat=, --category-filter=		  Filter by category
+		  Include only items with this category in the output. Additionally,
+		  the user can specify an exact match or full C#-style regex for
+		  pattern matching. Multiple instances of this flag are allowed.
+
+	  -ncat=, --not-category=	 Filter by not category
+		  Include only items without this category in the output.
+		  Additionally, the user can specify an exact match or full C#-style
+		  regex for pattern matching. Multiple instances of this flag are
+		  allowed.
+
 	  -gn=, --game-name=		  Filter by game name
 		  Include only items with this game name in the output. Additionally,
 		  the user can specify an exact match or full C#-style regex for
@@ -1532,6 +1555,17 @@ Options:
 		  Preprocess the DAT to have child sets contain all items from the
 		  parent sets based on the cloneof and romof tags as well as device
 		  references. This is incompatible with the other --dat-X flags.
+
+	  -cat=, --category-filter=		  Filter by category
+		  Include only items with this category in the output. Additionally,
+		  the user can specify an exact match or full C#-style regex for
+		  pattern matching. Multiple instances of this flag are allowed.
+
+	  -ncat=, --not-category=	 Filter by not category
+		  Include only items without this category in the output.
+		  Additionally, the user can specify an exact match or full C#-style
+		  regex for pattern matching. Multiple instances of this flag are
+		  allowed.
 
 	  -gn=, --game-name=		  Filter by game name
 		  Include only items with this game name in the output. Additionally,

--- a/SabreTools.Library/README.1ST
+++ b/SabreTools.Library/README.1ST
@@ -334,6 +334,15 @@ Options:
 		  compare against the input DATs. This flag forces all CHDs to be
 		  treated like regular files.
 
+	  -fi=, --filter=             Filter a game/rom field with the given value(s)
+		  Filter any valid item or machine field from inputs. Filters are input
+		  in the form 'key:value' or '!key:value', where the '!' signifies 'not'
+		  matching. Numeric values may also prefix the 'value' with '>', '<', or
+		  '=' accordingly. Key examples include: romof, category, and game.
+		  Additionally, the user can specify an exact match or full C#-style
+		  regex for pattern matching. Multiple instances of this flag are
+		  allowed.
+
 	  -cat=, --category-filter=		  Filter by category
 		  Include only items with this category in the output. Additionally,
 		  the user can specify an exact match or full C#-style regex for
@@ -1288,6 +1297,15 @@ Options:
 			  second time, this will skip writing it. This can often speed up
 			  the output process. [Both diff-cascade and diff-reverse-cascade]
 
+	  -fi=, --filter=             Filter a game/rom field with the given value(s)
+		  Filter any valid item or machine field from inputs. Filters are input
+		  in the form 'key:value' or '!key:value', where the '!' signifies 'not'
+		  matching. Numeric values may also prefix the 'value' with '>', '<', or
+		  '=' accordingly. Key examples include: romof, category, and game.
+		  Additionally, the user can specify an exact match or full C#-style
+		  regex for pattern matching. Multiple instances of this flag are
+		  allowed.
+
 	  -cat=, --category-filter=		  Filter by category
 		  Include only items with this category in the output. Additionally,
 		  the user can specify an exact match or full C#-style regex for
@@ -1555,6 +1573,15 @@ Options:
 		  Preprocess the DAT to have child sets contain all items from the
 		  parent sets based on the cloneof and romof tags as well as device
 		  references. This is incompatible with the other --dat-X flags.
+
+	  -fi=, --filter=             Filter a game/rom field with the given value(s)
+		  Filter any valid item or machine field from inputs. Filters are input
+		  in the form 'key:value' or '!key:value', where the '!' signifies 'not'
+		  matching. Numeric values may also prefix the 'value' with '>', '<', or
+		  '=' accordingly. Key examples include: romof, category, and game.
+		  Additionally, the user can specify an exact match or full C#-style
+		  regex for pattern matching. Multiple instances of this flag are
+		  allowed.
 
 	  -cat=, --category-filter=		  Filter by category
 		  Include only items with this category in the output. Additionally,

--- a/SabreTools.Library/Tools/Converters.cs
+++ b/SabreTools.Library/Tools/Converters.cs
@@ -122,49 +122,76 @@ namespace SabreTools.Library.Tools
             switch (input?.ToLowerInvariant())
             {
                 case "areaname":
+                case "area-name":
                     return Field.AreaName;
                 case "areasize":
+                case "area-size":
                     return Field.AreaSize;
                 case "bios":
                     return Field.Bios;
                 case "biosdescription":
-                case "bios description":
+                case "bios-description":
                 case "biossetdescription":
-                case "biosset description":
-                case "bios set description":
+                case "biosset-description":
+                case "bios-set-description":
                     return Field.BiosDescription;
                 case "board":
                     return Field.Board;
                 case "category":
                 case "machinecategory":
+                case "machine-category":
                     return Field.Category;
                 case "cloneof":
                     return Field.CloneOf;
                 case "comment":
                     return Field.Comment;
                 case "crc":
+                case "crc32":
                     return Field.CRC;
                 case "default":
                     return Field.Default;
                 case "date":
                     return Field.Date;
+                case "desc":
                 case "description":
+                case "gamedesc":
+                case "gamedescription":
+                case "game-description":
+                case "machinedesc":
+                case "machinedescription":
+                case "machine-description":
                     return Field.Description;
                 case "devices":
                     return Field.Devices;
+                case "equal":
+                case "greater":
+                case "less":
+                case "size":
+                    return Field.Size;
                 case "features":
                     return Field.Features;
                 case "gamename":
                 case "machinename":
                     return Field.MachineName;
                 case "gametype":
+                case "game-type":
                 case "machinetype":
+                case "machine-type":
                     return Field.MachineType;
                 case "index":
                     return Field.Index;
                 case "infos":
                     return Field.Infos;
+                case "itemname":
+                case "item-name":
+                case "name":
+                    return Field.Name;
+                case "itemtatus":
+                case "item-status":
+                case "status":
+                    return Field.Status;
                 case "itemtype":
+                case "item-type":
                 case "type":
                     return Field.ItemType;
                 case "language":
@@ -174,16 +201,18 @@ namespace SabreTools.Library.Tools
                 case "md5":
                     return Field.MD5;
                 case "merge":
+                case "mergetag":
+                case "merge-tag":
                     return Field.Merge;
-                case "name":
-                    return Field.Name;
                 case "offset":
                     return Field.Offset;
                 case "optional":
                     return Field.Optional;
                 case "partinterface":
+                case "part-interface":
                     return Field.PartInterface;
                 case "partname":
+                case "part-name":
                     return Field.PartName;
                 case "publisher":
                     return Field.Publisher;
@@ -202,21 +231,23 @@ namespace SabreTools.Library.Tools
                 case "sampleof":
                     return Field.SampleOf;
                 case "sha1":
+                case "sha-1":
                     return Field.SHA1;
                 case "sha256":
+                case "sha-256":
                     return Field.SHA256;
                 case "sha384":
+                case "sha-384":
                     return Field.SHA384;
                 case "sha512":
+                case "sha-512":
                     return Field.SHA512;
-                case "size":
-                    return Field.Size;
                 case "slotoptions":
+                case "slot-options":
                     return Field.SlotOptions;
                 case "sourcefile":
+                case "source-file":
                     return Field.SourceFile;
-                case "status":
-                    return Field.Status;
                 case "supported":
                     return Field.Supported;
                 case "writable":

--- a/SabreTools.Library/Tools/Converters.cs
+++ b/SabreTools.Library/Tools/Converters.cs
@@ -135,6 +135,9 @@ namespace SabreTools.Library.Tools
                     return Field.BiosDescription;
                 case "board":
                     return Field.Board;
+                case "category":
+                case "machinecategory":
+                    return Field.Category;
                 case "cloneof":
                     return Field.CloneOf;
                 case "comment":

--- a/SabreTools.Library/Tools/Converters.cs
+++ b/SabreTools.Library/Tools/Converters.cs
@@ -164,6 +164,9 @@ namespace SabreTools.Library.Tools
                     return Field.Index;
                 case "infos":
                     return Field.Infos;
+                case "itemtype":
+                case "type":
+                    return Field.ItemType;
                 case "language":
                     return Field.Language;
                 case "manufacturer":

--- a/SabreTools/SabreTools.Help.cs
+++ b/SabreTools/SabreTools.Help.cs
@@ -2351,108 +2351,108 @@ Some special strings that can be used:
                 if (features.ContainsKey(NotCategoryListValue))
                 {
                     Globals.Logger.User($"This flag '{NotCategoryListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("category", GetList(features, NotCategoryListValue), true);
+                    filter.SetFilter(Field.Category, GetList(features, NotCategoryListValue), true);
                 }
                 if (features.ContainsKey(CategoryListValue))
                 {
                     Globals.Logger.User($"This flag '{CategoryListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("category", GetList(features, CategoryListValue), false);
+                    filter.SetFilter(Field.Category, GetList(features, CategoryListValue), false);
                 }
 
                 // CRC
                 if (features.ContainsKey(NotCrcListValue))
                 {
                     Globals.Logger.User($"This flag '{NotCrcListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("crc", GetList(features, NotCrcListValue), true);
+                    filter.SetFilter(Field.CRC, GetList(features, NotCrcListValue), true);
                 }
                 if (features.ContainsKey(CrcListValue))
                 {
                     Globals.Logger.User($"This flag '{CrcListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("crc", GetList(features, NotCrcListValue), false);
+                    filter.SetFilter(Field.CRC, GetList(features, NotCrcListValue), false);
                 }
 
                 // Item name
                 if (features.ContainsKey(NotItemNameListValue))
                 {
                     Globals.Logger.User($"This flag '{NotItemNameListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("itemname", GetList(features, NotItemNameListValue), true);
+                    filter.SetFilter(Field.Name, GetList(features, NotItemNameListValue), true);
                 }
                 if (features.ContainsKey(ItemNameListValue))
                 {
                     Globals.Logger.User($"This flag '{ItemNameListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("itemname", GetList(features, ItemNameListValue), false);
+                    filter.SetFilter(Field.Name, GetList(features, ItemNameListValue), false);
                 }
 
                 // Item status
                 if (features.ContainsKey(NotStatusListValue))
                 {
                     Globals.Logger.User($"This flag '{NotStatusListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("status", GetList(features, NotStatusListValue), true);
+                    filter.SetFilter(Field.Status, GetList(features, NotStatusListValue), true);
                 }
                 if (features.ContainsKey(StatusListValue))
                 {
                     Globals.Logger.User($"This flag '{StatusListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("status", GetList(features, StatusListValue), false);
+                    filter.SetFilter(Field.Status, GetList(features, StatusListValue), false);
                 }
 
                 // Item type
                 if (features.ContainsKey(NotItemTypeListValue))
                 {
                     Globals.Logger.User($"This flag '{NotItemTypeListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("itemtype", GetList(features, NotItemTypeListValue), true);
+                    filter.SetFilter(Field.ItemType, GetList(features, NotItemTypeListValue), true);
                 }
                 if (features.ContainsKey(ItemTypeListValue))
                 {
                     Globals.Logger.User($"This flag '{ItemTypeListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("itemtype", GetList(features, ItemTypeListValue), false);
+                    filter.SetFilter(Field.ItemType, GetList(features, ItemTypeListValue), false);
                 }
 
                 // Machine description
                 if (features.ContainsKey(NotGameDescriptionListValue))
                 {
                     Globals.Logger.User($"This flag '{NotGameDescriptionListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("machinedesc", GetList(features, NotGameDescriptionListValue), true);
+                    filter.SetFilter(Field.Description, GetList(features, NotGameDescriptionListValue), true);
                 }
                 if (features.ContainsKey(GameDescriptionListValue))
                 {
                     Globals.Logger.User($"This flag '{GameDescriptionListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("machinedesc", GetList(features, GameDescriptionListValue), false);
+                    filter.SetFilter(Field.Description, GetList(features, GameDescriptionListValue), false);
                 }
 
                 // Machine name
                 if (features.ContainsKey(NotGameNameListValue))
                 {
                     Globals.Logger.User($"This flag '{NotGameNameListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("machinename", GetList(features, NotGameNameListValue), true);
+                    filter.SetFilter(Field.MachineName, GetList(features, NotGameNameListValue), true);
                 }
                 if (features.ContainsKey(GameNameListValue))
                 {
                     Globals.Logger.User($"This flag '{GameNameListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("machinename", GetList(features, GameNameListValue), false);
+                    filter.SetFilter(Field.MachineName, GetList(features, GameNameListValue), false);
                 }
 
                 // Machine type
                 if (features.ContainsKey(NotGameTypeListValue))
                 {
                     Globals.Logger.User($"This flag '{NotGameTypeListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("machinetype", GetList(features, NotGameTypeListValue), true);
+                    filter.SetFilter(Field.MachineType, GetList(features, NotGameTypeListValue), true);
                 }
                 if (features.ContainsKey(GameTypeListValue))
                 {
                     Globals.Logger.User($"This flag '{GameTypeListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("machinetype", GetList(features, GameTypeListValue), false);
+                    filter.SetFilter(Field.MachineType, GetList(features, GameTypeListValue), false);
                 }
 
                 // MD5
                 if (features.ContainsKey(NotMd5ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotMd5ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("md5", GetList(features, NotMd5ListValue), true);
+                    filter.SetFilter(Field.MD5, GetList(features, NotMd5ListValue), true);
                 }
                 if (features.ContainsKey(Md5ListValue))
                 {
                     Globals.Logger.User($"This flag '{Md5ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("md5", GetList(features, Md5ListValue), false);
+                    filter.SetFilter(Field.MD5, GetList(features, Md5ListValue), false);
                 }
 
 #if NET_FRAMEWORK
@@ -2460,12 +2460,12 @@ Some special strings that can be used:
                 if (features.ContainsKey(NotRipeMd160ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotRipeMd160ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("ripemd160", GetList(features, NotRipeMd160ListValue), true);
+                    filter.SetFilter(Field.RIPEMD160, GetList(features, NotRipeMd160ListValue), true);
                 }
                 if (features.ContainsKey(RipeMd160ListValue))
                 {
                     Globals.Logger.User($"This flag '{RipeMd160ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("ripemd160", GetList(features, RipeMd160ListValue), false);
+                    filter.SetFilter(Field.RIPEMD160, GetList(features, RipeMd160ListValue), false);
                 }
 #endif
 
@@ -2473,60 +2473,60 @@ Some special strings that can be used:
                 if (features.ContainsKey(NotRunnableValue))
                 {
                     Globals.Logger.User($"This flag '{NotRunnableValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("runnable", string.Empty, true);
+                    filter.SetFilter(Field.Runnable, string.Empty, true);
                 }
                 if (features.ContainsKey(RunnableValue))
                 {
                     Globals.Logger.User($"This flag '{RunnableValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("runnable", string.Empty, false);
+                    filter.SetFilter(Field.Runnable, string.Empty, false);
                 }
 
                 // SHA1
                 if (features.ContainsKey(NotSha1ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotSha1ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("sha1", GetList(features, NotSha1ListValue), true);
+                    filter.SetFilter(Field.SHA1, GetList(features, NotSha1ListValue), true);
                 }
                 if (features.ContainsKey(Sha1ListValue))
                 {
                     Globals.Logger.User($"This flag '{Sha1ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("sha1", GetList(features, Sha1ListValue), false);
+                    filter.SetFilter(Field.SHA1, GetList(features, Sha1ListValue), false);
                 }
 
                 // SHA256
                 if (features.ContainsKey(NotSha256ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotSha256ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("sha256", GetList(features, NotSha256ListValue), true);
+                    filter.SetFilter(Field.SHA256, GetList(features, NotSha256ListValue), true);
                 }
                 if (features.ContainsKey(Sha256ListValue))
                 {
                     Globals.Logger.User($"This flag '{Sha256ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("sha256", GetList(features, Sha256ListValue), false);
+                    filter.SetFilter(Field.SHA256, GetList(features, Sha256ListValue), false);
                 }
 
                 // SHA384
                 if (features.ContainsKey(NotSha384ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotSha384ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("sha384", GetList(features, NotSha384ListValue), true);
+                    filter.SetFilter(Field.SHA384, GetList(features, NotSha384ListValue), true);
                 }
                 if (features.ContainsKey(Sha384ListValue))
                 {
                     Globals.Logger.User($"This flag '{Sha384ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("sha384", GetList(features, Sha384ListValue), false);
+                    filter.SetFilter(Field.SHA384, GetList(features, Sha384ListValue), false);
                 }
 
                 // SHA512
                 if (features.ContainsKey(NotSha512ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotSha512ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("sha512", GetList(features, NotSha512ListValue), true);
+                    filter.SetFilter(Field.SHA512, GetList(features, NotSha512ListValue), true);
                 }
                 if (features.ContainsKey(Sha512ListValue))
                 {
                     Globals.Logger.User($"This flag '{Sha512ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filter.SetFilter("sha512", GetList(features, Sha512ListValue), false);
+                    filter.SetFilter(Field.SHA512, GetList(features, Sha512ListValue), false);
                 }
 
                 // Size
@@ -2534,19 +2534,19 @@ Some special strings that can be used:
                 {
                     Globals.Logger.User($"This flag '{LessStringValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
                     var value = Sanitizer.ToSize(GetString(features, LessStringValue));
-                    filter.SetFilter("size", $"<{value}", false);
+                    filter.SetFilter(Field.Size, $"<{value}", false);
                 }
                 if (features.ContainsKey(EqualStringValue))
                 {
                     Globals.Logger.User($"This flag '{EqualStringValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
                     var value = Sanitizer.ToSize(GetString(features, EqualStringValue));
-                    filter.SetFilter("size", $"={value}", false);
+                    filter.SetFilter(Field.Size, $"={value}", false);
                 }
                 if (features.ContainsKey(GreaterStringValue))
                 {
                     Globals.Logger.User($"This flag '{GreaterStringValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
                     var value = Sanitizer.ToSize(GetString(features, GreaterStringValue));
-                    filter.SetFilter("size", $">{value}", false);
+                    filter.SetFilter(Field.Size, $">{value}", false);
                 }
 
                 #endregion

--- a/SabreTools/SabreTools.Help.cs
+++ b/SabreTools/SabreTools.Help.cs
@@ -2354,11 +2354,11 @@ Some special strings that can be used:
                 // Item status
                 foreach (string stat in GetList(features, NotStatusListValue))
                 {
-                    filter.ItemStatuses.Negative |= stat.AsItemStatus();
+                    filter.Status.Negative |= stat.AsItemStatus();
                 }
                 foreach (string stat in GetList(features, StatusListValue))
                 {
-                    filter.ItemStatuses.Positive |= stat.AsItemStatus();
+                    filter.Status.Positive |= stat.AsItemStatus();
                 }
 
                 // Item type

--- a/SabreTools/SabreTools.Help.cs
+++ b/SabreTools/SabreTools.Help.cs
@@ -1269,6 +1269,20 @@ namespace SabreTools
             }
         }
 
+        public const string CategoryListValue = "category-filter";
+        private static Feature CategoryListInput
+        {
+            get
+            {
+                return new Feature(
+                    CategoryListValue,
+                    new List<string>() { "-cat", "--category-filter" },
+                    "Filter by Category",
+                    FeatureType.List,
+                    longDescription: "Include only items with this Category in the output. Additionally, the user can specify an exact match or full C#-style regex for pattern matching. Multiple instances of this flag are allowed.");
+            }
+        }
+
         public const string CrcListValue = "crc";
         private static Feature CrcListInput
         {
@@ -1421,6 +1435,20 @@ Possible values are: None, Bios, Device, Mechanical");
                     "Filter by MD5 hash",
                     FeatureType.List,
                     longDescription: "Include only items with this MD5 hash in the output. Additionally, the user can specify an exact match or full C#-style regex for pattern matching. Multiple instances of this flag are allowed.");
+            }
+        }
+
+        public const string NotCategoryListValue = "not-category";
+        private static Feature NotCategoryListInput
+        {
+            get
+            {
+                return new Feature(
+                    NotCategoryListValue,
+                    new List<string>() { "-ncat", "--not-category" },
+                    "Filter by not Category",
+                    FeatureType.List,
+                    longDescription: "Include only items without this Category in the output. Additionally, the user can specify an exact match or full C#-style regex for pattern matching. Multiple instances of this flag are allowed.");
             }
         }
 
@@ -2055,6 +2083,7 @@ Some special strings that can be used:
 - %name% - Replaced with the Rom name
 - %manufacturer% - Replaced with game Manufacturer
 - %publisher% - Replaced with game Publisher
+- %category% - Replaced with game Category
 - %crc% - Replaced with the CRC
 - %md5% - Replaced with the MD5"
 #if NET_FRAMEWORK
@@ -2087,6 +2116,7 @@ Some special strings that can be used:
 - %name% - Replaced with the Rom name
 - %manufacturer% - Replaced with game Manufacturer
 - %publisher% - Replaced with game Publisher
+- %category% - Replaced with game Category
 - %crc% - Replaced with the CRC
 - %md5% - Replaced with the MD5
 - %sha1% - Replaced with the SHA-1
@@ -2296,6 +2326,10 @@ Some special strings that can be used:
             protected Filter GetFilter(Dictionary<string, Feature> features)
             {
                 Filter filter = new Filter();
+
+                // Category
+                filter.Category.NegativeSet.AddRange(GetList(features, NotCategoryListValue));
+                filter.Category.PositiveSet.AddRange(GetList(features, CategoryListValue));
 
                 // Clean names
                 filter.Clean.Neutral = GetBoolean(features, CleanValue);
@@ -2714,6 +2748,8 @@ Some special strings that can be used:
                 AddFeature(CopyFilesFlag);
                 AddFeature(HeaderStringInput);
                 AddFeature(ChdsAsFilesFlag);
+                AddFeature(CategoryListInput);
+                AddFeature(NotCategoryListInput);
                 AddFeature(GameNameListInput);
                 AddFeature(NotGameNameListInput);
                 AddFeature(GameDescriptionListInput);
@@ -3238,6 +3274,8 @@ The stats that are outputted are as follows:
                 this[DiffCascadeFlag].AddFeature(SkipFirstOutputFlag);
                 AddFeature(DiffReverseCascadeFlag);
                 this[DiffReverseCascadeFlag].AddFeature(SkipFirstOutputFlag);
+                AddFeature(CategoryListInput);
+                AddFeature(NotCategoryListInput);
                 AddFeature(GameNameListInput);
                 AddFeature(NotGameNameListInput);
                 AddFeature(GameDescriptionListInput);
@@ -3369,6 +3407,8 @@ The stats that are outputted are as follows:
                 AddFeature(DatDeviceNonMergedFlag);
                 AddFeature(DatNonMergedFlag);
                 AddFeature(DatFullNonMergedFlag);
+                AddFeature(CategoryListInput);
+                AddFeature(NotCategoryListInput);
                 AddFeature(GameNameListInput);
                 AddFeature(NotGameNameListInput);
                 AddFeature(GameDescriptionListInput);

--- a/SabreTools/SabreTools.Help.cs
+++ b/SabreTools/SabreTools.Help.cs
@@ -2341,320 +2341,192 @@ Some special strings that can be used:
             {
                 Filter filter = new Filter();
 
+                // Use the Filter flag first
                 List<string> filterPairs = GetList(features, FilterListValue);
+                filter.PopulateFromList(filterPairs);
+
+                #region Obsoleted Inputs
 
                 // Category
-                var notCategory = GetList(features, NotCategoryListValue);
-                if (notCategory.Count != 0)
+                if (features.ContainsKey(NotCategoryListValue))
                 {
                     Globals.Logger.User($"This flag '{NotCategoryListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notCategory)
-                    {
-                        filterPairs.Add($"!category:{s}");
-                    }
+                    filter.SetFilter("category", GetList(features, NotCategoryListValue), true);
                 }
-
-                var category = GetList(features, CategoryListValue);
-                if (category.Count != 0)
+                if (features.ContainsKey(CategoryListValue))
                 {
                     Globals.Logger.User($"This flag '{CategoryListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in category)
-                    {
-                        filterPairs.Add($"category:{s}");
-                    }
+                    filter.SetFilter("category", GetList(features, CategoryListValue), false);
                 }
 
                 // CRC
-                var notCrc = GetList(features, NotCrcListValue);
-                if (notCrc.Count != 0)
+                if (features.ContainsKey(NotCrcListValue))
                 {
                     Globals.Logger.User($"This flag '{NotCrcListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notCrc)
-                    {
-                        filterPairs.Add($"!crc:{s}");
-                    }
+                    filter.SetFilter("crc", GetList(features, NotCrcListValue), true);
                 }
-
-                var crc = GetList(features, CrcListValue);
-                if (crc.Count != 0)
+                if (features.ContainsKey(CrcListValue))
                 {
                     Globals.Logger.User($"This flag '{CrcListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in crc)
-                    {
-                        filterPairs.Add($"crc:{s}");
-                    }
+                    filter.SetFilter("crc", GetList(features, NotCrcListValue), false);
                 }
 
                 // Item name
-                var notItemName = GetList(features, NotItemNameListValue);
-                if (notItemName.Count != 0)
+                if (features.ContainsKey(NotItemNameListValue))
                 {
                     Globals.Logger.User($"This flag '{NotItemNameListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notItemName)
-                    {
-                        filterPairs.Add($"!itemname:{s}");
-                    }
+                    filter.SetFilter("itemname", GetList(features, NotItemNameListValue), true);
                 }
-
-                var itemName = GetList(features, ItemNameListValue);
-                if (itemName.Count != 0)
+                if (features.ContainsKey(ItemNameListValue))
                 {
                     Globals.Logger.User($"This flag '{ItemNameListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in itemName)
-                    {
-                        filterPairs.Add($"itemname:{s}");
-                    }
+                    filter.SetFilter("itemname", GetList(features, ItemNameListValue), false);
                 }
 
                 // Item status
-                var notItemStatus = GetList(features, NotStatusListValue);
-                if (notItemStatus.Count != 0)
+                if (features.ContainsKey(NotStatusListValue))
                 {
                     Globals.Logger.User($"This flag '{NotStatusListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notItemStatus)
-                    {
-                        filterPairs.Add($"!status:{s}");
-                    }
+                    filter.SetFilter("status", GetList(features, NotStatusListValue), true);
                 }
-
-                var itemStatus = GetList(features, StatusListValue);
-                if (itemStatus.Count != 0)
+                if (features.ContainsKey(StatusListValue))
                 {
                     Globals.Logger.User($"This flag '{StatusListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in itemStatus)
-                    {
-                        filterPairs.Add($"status:{s}");
-                    }
+                    filter.SetFilter("status", GetList(features, StatusListValue), false);
                 }
 
                 // Item type
-                var notItemType = GetList(features, NotItemTypeListValue);
-                if (notItemType.Count != 0)
+                if (features.ContainsKey(NotItemTypeListValue))
                 {
                     Globals.Logger.User($"This flag '{NotItemTypeListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notItemType)
-                    {
-                        filterPairs.Add($"!itemtype:{s}");
-                    }
+                    filter.SetFilter("itemtype", GetList(features, NotItemTypeListValue), true);
                 }
-
-                var itemType = GetList(features, ItemTypeListValue);
-                if (itemType.Count != 0)
+                if (features.ContainsKey(ItemTypeListValue))
                 {
                     Globals.Logger.User($"This flag '{ItemTypeListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in itemType)
-                    {
-                        filterPairs.Add($"itemtype:{s}");
-                    }
+                    filter.SetFilter("itemtype", GetList(features, ItemTypeListValue), false);
                 }
 
                 // Machine description
-                var notMachineDescription = GetList(features, NotGameDescriptionListValue);
-                if (notMachineDescription.Count != 0)
+                if (features.ContainsKey(NotGameDescriptionListValue))
                 {
                     Globals.Logger.User($"This flag '{NotGameDescriptionListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notMachineDescription)
-                    {
-                        filterPairs.Add($"!machinedesc:{s}");
-                    }
+                    filter.SetFilter("machinedesc", GetList(features, NotGameDescriptionListValue), true);
                 }
-
-                var machineDescription = GetList(features, GameDescriptionListValue);
-                if (machineDescription.Count != 0)
+                if (features.ContainsKey(GameDescriptionListValue))
                 {
                     Globals.Logger.User($"This flag '{GameDescriptionListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in machineDescription)
-                    {
-                        filterPairs.Add($"machinedesc:{s}");
-                    }
+                    filter.SetFilter("machinedesc", GetList(features, GameDescriptionListValue), false);
                 }
 
                 // Machine name
-                var notMachineName = GetList(features, NotGameNameListValue);
-                if (notMachineName.Count != 0)
+                if (features.ContainsKey(NotGameNameListValue))
                 {
                     Globals.Logger.User($"This flag '{NotGameNameListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notMachineName)
-                    {
-                        filterPairs.Add($"!machinename:{s}");
-                    }
+                    filter.SetFilter("machinename", GetList(features, NotGameNameListValue), true);
                 }
-
-                var machineName = GetList(features, GameNameListValue);
-                if (machineName.Count != 0)
+                if (features.ContainsKey(GameNameListValue))
                 {
                     Globals.Logger.User($"This flag '{GameNameListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in machineName)
-                    {
-                        filterPairs.Add($"machinename:{s}");
-                    }
+                    filter.SetFilter("machinename", GetList(features, GameNameListValue), false);
                 }
 
                 // Machine type
-                var notMachineType = GetList(features, NotGameTypeListValue);
-                if (notMachineType.Count != 0)
+                if (features.ContainsKey(NotGameTypeListValue))
                 {
                     Globals.Logger.User($"This flag '{NotGameTypeListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notMachineType)
-                    {
-                        filterPairs.Add($"!machinetype:{s}");
-                    }
+                    filter.SetFilter("machinetype", GetList(features, NotGameTypeListValue), true);
                 }
-
-                var machineType = GetList(features, GameTypeListValue);
-                if (machineType.Count != 0)
+                if (features.ContainsKey(GameTypeListValue))
                 {
                     Globals.Logger.User($"This flag '{GameTypeListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in machineType)
-                    {
-                        filterPairs.Add($"machinetype:{s}");
-                    }
+                    filter.SetFilter("machinetype", GetList(features, GameTypeListValue), false);
                 }
 
                 // MD5
-                var notMd5 = GetList(features, NotMd5ListValue);
-                if (notMd5.Count != 0)
+                if (features.ContainsKey(NotMd5ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotMd5ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notMd5)
-                    {
-                        filterPairs.Add($"!md5:{s}");
-                    }
+                    filter.SetFilter("md5", GetList(features, NotMd5ListValue), true);
                 }
-
-                var md5 = GetList(features, Md5ListValue);
-                if (md5.Count != 0)
+                if (features.ContainsKey(Md5ListValue))
                 {
                     Globals.Logger.User($"This flag '{Md5ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in md5)
-                    {
-                        filterPairs.Add($"md5:{s}");
-                    }
+                    filter.SetFilter("md5", GetList(features, Md5ListValue), false);
                 }
 
 #if NET_FRAMEWORK
                 // RIPEMD160
-                var notRipemd160 = GetList(features, NotRipeMd160ListValue);
-                if (notRipemd160.Count != 0)
+                if (features.ContainsKey(NotRipeMd160ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotRipeMd160ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notRipemd160)
-                    {
-                        filterPairs.Add($"!ripemd160:{s}");
-                    }
+                    filter.SetFilter("ripemd160", GetList(features, NotRipeMd160ListValue), true);
                 }
-
-                var ripemd160 = GetList(features, RipeMd160ListValue);
-                if (ripemd160.Count != 0)
+                if (features.ContainsKey(RipeMd160ListValue))
                 {
                     Globals.Logger.User($"This flag '{RipeMd160ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in ripemd160)
-                    {
-                        filterPairs.Add($"ripemd160:{s}");
-                    }
+                    filter.SetFilter("ripemd160", GetList(features, RipeMd160ListValue), false);
                 }
 #endif
 
-                // Root directory
-                filter.Root = GetString(features, RootDirStringValue);
-
                 // Runnable
-                var notRunnable = GetBoolean(features, NotRunnableValue);
-                if (notRunnable)
+                if (features.ContainsKey(NotRunnableValue))
                 {
                     Globals.Logger.User($"This flag '{NotRunnableValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"!runnable:");
+                    filter.SetFilter("runnable", string.Empty, true);
                 }
-
-                var runnable = GetBoolean(features, RunnableValue);
-                if (runnable)
+                if (features.ContainsKey(RunnableValue))
                 {
                     Globals.Logger.User($"This flag '{RunnableValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"runnable:");
+                    filter.SetFilter("runnable", string.Empty, false);
                 }
 
                 // SHA1
-                var notSha1 = GetList(features, NotSha1ListValue);
-                if (notSha1.Count != 0)
+                if (features.ContainsKey(NotSha1ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotSha1ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notSha1)
-                    {
-                        filterPairs.Add($"!sha1:{s}");
-                    }
+                    filter.SetFilter("sha1", GetList(features, NotSha1ListValue), true);
                 }
-
-                var sha1 = GetList(features, Sha1ListValue);
-                if (sha1.Count != 0)
+                if (features.ContainsKey(Sha1ListValue))
                 {
                     Globals.Logger.User($"This flag '{Sha1ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in sha1)
-                    {
-                        filterPairs.Add($"sha1:{s}");
-                    }
+                    filter.SetFilter("sha1", GetList(features, Sha1ListValue), false);
                 }
 
                 // SHA256
-                var notSha256 = GetList(features, NotSha256ListValue);
-                if (notSha256.Count != 0)
+                if (features.ContainsKey(NotSha256ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotSha256ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notSha256)
-                    {
-                        filterPairs.Add($"!sha256:{s}");
-                    }
+                    filter.SetFilter("sha256", GetList(features, NotSha256ListValue), true);
                 }
-
-                var sha256 = GetList(features, Sha256ListValue);
-                if (sha256.Count != 0)
+                if (features.ContainsKey(Sha256ListValue))
                 {
                     Globals.Logger.User($"This flag '{Sha256ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in sha256)
-                    {
-                        filterPairs.Add($"sha256:{s}");
-                    }
+                    filter.SetFilter("sha256", GetList(features, Sha256ListValue), false);
                 }
 
                 // SHA384
-                var notSha384 = GetList(features, NotSha384ListValue);
-                if (notSha384.Count != 0)
+                if (features.ContainsKey(NotSha384ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotSha384ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notSha384)
-                    {
-                        filterPairs.Add($"!sha384:{s}");
-                    }
+                    filter.SetFilter("sha384", GetList(features, NotSha384ListValue), true);
                 }
-
-                var sha384 = GetList(features, Sha384ListValue);
-                if (sha384.Count != 0)
+                if (features.ContainsKey(Sha384ListValue))
                 {
                     Globals.Logger.User($"This flag '{Sha384ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in sha384)
-                    {
-                        filterPairs.Add($"sha384:{s}");
-                    }
+                    filter.SetFilter("sha384", GetList(features, Sha384ListValue), false);
                 }
 
                 // SHA512
-                var notSha512 = GetList(features, NotSha512ListValue);
-                if (notSha512.Count != 0)
+                if (features.ContainsKey(NotSha512ListValue))
                 {
                     Globals.Logger.User($"This flag '{NotSha512ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in notSha512)
-                    {
-                        filterPairs.Add($"!sha512:{s}");
-                    }
+                    filter.SetFilter("sha512", GetList(features, NotSha512ListValue), true);
                 }
-
-                var sha512 = GetList(features, Sha512ListValue);
-                if (sha512.Count != 0)
+                if (features.ContainsKey(Sha512ListValue))
                 {
                     Globals.Logger.User($"This flag '{Sha512ListValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    foreach (string s in sha512)
-                    {
-                        filterPairs.Add($"sha512:{s}");
-                    }
+                    filter.SetFilter("sha512", GetList(features, Sha512ListValue), false);
                 }
 
                 // Size
@@ -2662,25 +2534,24 @@ Some special strings that can be used:
                 {
                     Globals.Logger.User($"This flag '{LessStringValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
                     var value = Sanitizer.ToSize(GetString(features, LessStringValue));
-                    filterPairs.Add($"size:<{value}");
+                    filter.SetFilter("size", $"<{value}", false);
                 }
-
                 if (features.ContainsKey(EqualStringValue))
                 {
                     Globals.Logger.User($"This flag '{EqualStringValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
                     var value = Sanitizer.ToSize(GetString(features, EqualStringValue));
-                    filterPairs.Add($"size:={value}");
+                    filter.SetFilter("size", $"={value}", false);
                 }
-
                 if (features.ContainsKey(GreaterStringValue))
                 {
                     Globals.Logger.User($"This flag '{GreaterStringValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
                     var value = Sanitizer.ToSize(GetString(features, GreaterStringValue));
-                    filterPairs.Add($"size:>{value}");
+                    filter.SetFilter("size", $">{value}", false);
                 }
 
-                // Populate the remaining filter fields
-                filter.PopulateFromList(filterPairs);
+                #endregion
+
+                #region Filter manipulation flags
 
                 // Clean names
                 filter.Clean = GetBoolean(features, CleanValue);
@@ -2697,11 +2568,16 @@ Some special strings that can be used:
                 // Remove unicode characters
                 filter.RemoveUnicode = GetBoolean(features, RemoveUnicodeValue);
 
+                // Root directory
+                filter.Root = GetString(features, RootDirStringValue);
+
                 // Single game in output
                 filter.Single = GetBoolean(features, SingleSetValue);
 
                 // Trim to NTFS length
                 filter.Trim = GetBoolean(features, TrimValue);
+
+                #endregion
 
                 return filter;
             }

--- a/SabreTools/SabreTools.Help.cs
+++ b/SabreTools/SabreTools.Help.cs
@@ -2337,7 +2337,6 @@ Some special strings that can be used:
             /// <summary>
             /// Get Filter from feature list
             /// </summary>
-            /// TODO: Re-enable logging on cleanup filters
             protected Filter GetFilter(Dictionary<string, Feature> features)
             {
                 Filter filter = new Filter();
@@ -2365,13 +2364,6 @@ Some special strings that can be used:
                     }
                 }
 
-                // Clean names
-                if (features.ContainsKey(CleanValue))
-                {
-                    //Globals.Logger.User($"This flag '{CleanValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"clean:{GetBoolean(features, CleanValue)}");
-                }
-
                 // CRC
                 var notCrc = GetList(features, NotCrcListValue);
                 if (notCrc.Count != 0)
@@ -2391,28 +2383,6 @@ Some special strings that can be used:
                     {
                         filterPairs.Add($"crc:{s}");
                     }
-                }
-
-                // Machine description as machine name
-                if (features.ContainsKey(DescriptionAsNameValue))
-                {
-                    //Globals.Logger.User($"This flag '{DescriptionAsNameValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"descasname:{GetBoolean(features, DescriptionAsNameValue)}");
-                }
-
-                // Include 'of" in game filters
-                if (features.ContainsKey(MatchOfTagsValue))
-                {
-                    //Globals.Logger.User($"This flag '{MatchOfTagsValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"matchoftags:{GetBoolean(features, MatchOfTagsValue)}");
-                }
-
-                // Internal splitting
-                (SplitType splitType, string splitValue, string newkey) = GetSplitType(features);
-                if (splitType != SplitType.None)
-                {
-                    //Globals.Logger.User($"This flag '{splitValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"splittype:{newkey}");
                 }
 
                 // Item name
@@ -2562,13 +2532,6 @@ Some special strings that can be used:
                     }
                 }
 
-                // Remove unicode characters
-                if (features.ContainsKey(RemoveUnicodeValue))
-                {
-                    //Globals.Logger.User($"This flag '{RemoveUnicodeValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"remunicode:{GetBoolean(features, RemoveUnicodeValue)}");
-                }
-
 #if NET_FRAMEWORK
                 // RIPEMD160
                 var notRipemd160 = GetList(features, NotRipeMd160ListValue);
@@ -2593,11 +2556,7 @@ Some special strings that can be used:
 #endif
 
                 // Root directory
-                if (features.ContainsKey(RootDirStringValue))
-                {
-                    //Globals.Logger.User($"This flag '{RootDirStringValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"rootdir:{GetString(features, RootDirStringValue)}");
-                }
+                filter.Root = GetString(features, RootDirStringValue);
 
                 // Runnable
                 var notRunnable = GetBoolean(features, NotRunnableValue);
@@ -2698,13 +2657,6 @@ Some special strings that can be used:
                     }
                 }
 
-                // Single game in output
-                if (features.ContainsKey(SingleSetValue))
-                {
-                    //Globals.Logger.User($"This flag '{SingleSetValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"single:{GetBoolean(features, SingleSetValue)}");
-                }
-
                 // Size
                 if (features.ContainsKey(LessStringValue))
                 {
@@ -2727,14 +2679,29 @@ Some special strings that can be used:
                     filterPairs.Add($"size:>{value}");
                 }
 
-                // Trim to NTFS length
-                if (features.ContainsKey(TrimValue))
-                {
-                    //Globals.Logger.User($"This flag '{TrimValue}' is deprecated, please use {string.Join(", ", FilterListInput.Flags)} instead");
-                    filterPairs.Add($"trim:{GetBoolean(features, TrimValue)}");
-                }
-
+                // Populate the remaining filter fields
                 filter.PopulateFromList(filterPairs);
+
+                // Clean names
+                filter.Clean = GetBoolean(features, CleanValue);
+
+                // Machine description as machine name
+                filter.DescriptionAsName = GetBoolean(features, DescriptionAsNameValue);
+
+                // Include 'of" in game filters
+                filter.IncludeOfInGame = GetBoolean(features, MatchOfTagsValue);
+
+                // Internal splitting
+                filter.InternalSplit = GetSplitType(features);
+
+                // Remove unicode characters
+                filter.RemoveUnicode = GetBoolean(features, RemoveUnicodeValue);
+
+                // Single game in output
+                filter.Single = GetBoolean(features, SingleSetValue);
+
+                // Trim to NTFS length
+                filter.Trim = GetBoolean(features, TrimValue);
 
                 return filter;
             }
@@ -2809,44 +2776,21 @@ Some special strings that can be used:
             /// <summary>
             /// Get SplitType from feature list
             /// </summary>
-            protected (SplitType, string, string) GetSplitType(Dictionary<string, Feature> features)
+            protected SplitType GetSplitType(Dictionary<string, Feature> features)
             {
                 SplitType splitType = SplitType.None;
-                string value = string.Empty;
-                string newkey = string.Empty;
-
                 if (GetBoolean(features, DatDeviceNonMergedValue))
-                {
                     splitType = SplitType.DeviceNonMerged;
-                    value = DatDeviceNonMergedValue;
-                    newkey = "dnm";
-                }
                 else if (GetBoolean(features, DatFullNonMergedValue))
-                {
                     splitType = SplitType.FullNonMerged;
-                    value = DatFullNonMergedValue;
-                    newkey = "fnm";
-                }
                 else if (GetBoolean(features, DatMergedValue))
-                {
                     splitType = SplitType.Merged;
-                    value = DatMergedValue;
-                    newkey = "m";
-                }
                 else if (GetBoolean(features, DatNonMergedValue))
-                {
                     splitType = SplitType.NonMerged;
-                    value = DatNonMergedValue;
-                    newkey = "nm";
-                }
                 else if (GetBoolean(features, DatSplitValue))
-                {
                     splitType = SplitType.Split;
-                    value = DatSplitValue;
-                    newkey = "s";
-                }
 
-                return (splitType, value, newkey);
+                return splitType;
             }
 
             /// <summary>


### PR DESCRIPTION
This is a major overhaul to the filtering system in SabreTools. Notably, this adds the same generic "all machine and all datitem fields" trickery that I added for excluding from output. This also adds support for the Category tag that is present in Redump datfiles.

The new rules for filtering that are added are as follows:
- The new flag is `-fi, --filter` taking a string input
- Each filter input is of the form `key:value`. Only one filter is allowed per instance of the flag.
- The key can be prepended with `!` or `~` to denote negation of the filter (for example, `gamename` would be only include game names that match while `!gamename` would be only include game names that don't match)
- The value only allows a character prepended if the field is numeric, such as size. All other field types, the entire value is understood as part of the filter. Numeric fields allow for `<` for less than or equal, `>` for greater than or equal, and `=` for equal (same as omitting the `=`). Note that both the negation key prefix and comparator value prefix can be combined. For example, `!size:=1024` would be the equivalent of `size not equal to 1024`. This can also allow for strictly less than or strictly greater than.