### PR TITLE
delete can only act on file

### DIFF
--- a/SabreTools.DatTools/Rebuilder.cs
+++ b/SabreTools.DatTools/Rebuilder.cs
@@ -239,8 +239,10 @@ namespace SabreTools.DatTools
                         bool rebuilt = RebuildGenericHelper(datFile, file, outDir, quickScan, date, inverse, outputFormat, asFiles);
 
                         // If we are supposed to delete the file, do so
-                        if (delete && rebuilt)
-                            File.Delete(input);
+                        if (delete && rebuilt) {
+                            File.SetAttributes(file, FileAttributes.Normal);
+                            File.Delete(file);
+                        }
                     }
                 }
             }

--- a/SabreTools.DatTools/Rebuilder.cs
+++ b/SabreTools.DatTools/Rebuilder.cs
@@ -249,12 +249,27 @@ namespace SabreTools.DatTools
                         // If we are supposed to delete the file, do so
                         if (delete && rebuilt) {
                             try {
-                                Directory.Delete(input);
+                                File.SetAttributes(file, FileAttributes.Normal);
+                                File.Delete(file);
+                                // sometimes the file is in a directory (TOSEC), delete directory
+                                Directory.Delete(Path.GetDirectoryName(file));
                             }
                             catch (Exception e)
                             {
                                 logger.Warning("The process failed: " + e.Message);
                             }
+                        }
+                    }
+                    
+                    // lopping through directories, delete them also 
+                    // directory is not deleted, if files remain in it
+                    if (delete) {
+                        try {
+                            Directory.Delete(input);
+                        }
+                        catch (Exception e)
+                        {
+                            logger.Warning("Directory was not deleted, if there are still files left: " + e.Message);
                         }
                     }
                 }

--- a/SabreTools.DatTools/Rebuilder.cs
+++ b/SabreTools.DatTools/Rebuilder.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -227,14 +227,17 @@ namespace SabreTools.DatTools
 
                     // If we are supposed to delete the file, do so
                     if (delete && rebuilt)
-                            try {
+                    {
+                            try 
+                            {
                                 File.SetAttributes(input, FileAttributes.Normal);
                                 File.Delete(input);
                             }
                             catch (Exception e)
                             {
                                 logger.Warning("The process failed: " + e.Message);
-                            }   
+                            }
+                    }
                 }
 
                 // If the input is a directory
@@ -247,8 +250,10 @@ namespace SabreTools.DatTools
                         bool rebuilt = RebuildGenericHelper(datFile, file, outDir, quickScan, date, inverse, outputFormat, asFiles);
 
                         // If we are supposed to delete the file, do so
-                        if (delete && rebuilt) {
-                            try {
+                        if (delete && rebuilt) 
+                        {
+                            try 
+                            {
                                 File.SetAttributes(file, FileAttributes.Normal);
                                 File.Delete(file);
                                 // sometimes the file is in a directory (TOSEC), delete directory
@@ -264,7 +269,8 @@ namespace SabreTools.DatTools
                     // lopping through directories, delete them also 
                     // directory is not deleted, if files remain in it
                     if (delete) {
-                        try {
+                        try 
+                        {
                             Directory.Delete(input);
                         }
                         catch (Exception e)

--- a/SabreTools.DatTools/Rebuilder.cs
+++ b/SabreTools.DatTools/Rebuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -226,7 +227,14 @@ namespace SabreTools.DatTools
 
                     // If we are supposed to delete the file, do so
                     if (delete && rebuilt)
-                        File.Delete(input);
+                            try {
+                                File.SetAttributes(input, FileAttributes.Normal);
+                                File.Delete(input);
+                            }
+                            catch (Exception e)
+                            {
+                                logger.Warning("The process failed: " + e.Message);
+                            }   
                 }
 
                 // If the input is a directory
@@ -240,8 +248,13 @@ namespace SabreTools.DatTools
 
                         // If we are supposed to delete the file, do so
                         if (delete && rebuilt) {
-                            File.SetAttributes(file, FileAttributes.Normal);
-                            File.Delete(file);
+                            try {
+                                Directory.Delete(input);
+                            }
+                            catch (Exception e)
+                            {
+                                logger.Warning("The process failed: " + e.Message);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
input is the directory, which run into an unhandled exception. For a proper use this should be a try ... catch at the end.
File.SetAttributes added see https://stackoverflow.com/questions/8821410/why-is-access-to-the-path-denied