### PR TITLE
Add some Features to sort

### DIFF
--- a/SabreTools.DatTools/Rebuilder.cs
+++ b/SabreTools.DatTools/Rebuilder.cs
@@ -1,4 +1,7 @@
+using System.ComponentModel;
+using System.Security.Principal;
 using System.Collections.Generic;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -27,6 +30,7 @@ namespace SabreTools.DatTools
         /// Logging object
         /// </summary>
         private static readonly Logger logger = new Logger();
+        private static string symlinkDirReport = "";
 
         #endregion
 
@@ -48,6 +52,9 @@ namespace SabreTools.DatTools
             bool date = false,
             bool delete = false,
             bool inverse = false,
+            bool baseReplace = false,
+            bool archivesAsFiles = false,
+            string symlinkDir = "",
             OutputFormat outputFormat = OutputFormat.Folder)
         {
             #region Perform setup

--- a/SabreTools.DatTools/Rebuilder.cs
+++ b/SabreTools.DatTools/Rebuilder.cs
@@ -188,10 +188,10 @@ namespace SabreTools.DatTools
             bool quickScan = false,
             bool date = false,
             bool delete = false,
+            bool inverse = false,
             bool baseReplace = false,
             bool archivesAsFiles = false,
             string symlinkDir = "",           
-            bool inverse = false,
             OutputFormat outputFormat = OutputFormat.Folder,
             TreatAsFile asFiles = 0x00)
         {

--- a/SabreTools/Features/BaseFeature.cs
+++ b/SabreTools/Features/BaseFeature.cs
@@ -1705,6 +1705,20 @@ Some special strings that can be used:
             }
         }
 
+        internal const string SymlinkDirStringValue = "symlink-dir";
+        internal static Feature SymlinkStringInput
+        {
+            get
+            {
+                return new Feature(
+                    SymlinkDirStringValue,
+                    new List<string>() { "-sd", "--symlink-dir" },
+                    "Set the root directory for calc",
+                    ParameterType.String,
+                    longDescription: "In the case that the files will not be stored from the root directory, a new root can be set for path length calculations.");
+            }
+        }
+        
         internal const string UrlStringValue = "url";
         internal static Feature UrlStringInput
         {

--- a/SabreTools/Features/Sort.cs
+++ b/SabreTools/Features/Sort.cs
@@ -50,6 +50,9 @@ namespace SabreTools.Features
             //AddFeature(SharedInputs.TorrentXzFlag);
             //this[SharedInputs.TorrentXzFlag].AddFeature(SharedInputs.RombaFlag);
             AddFeature(TorrentZipFlag);
+            AddFeature(BaseReplaceFlag); // change name of folder or zip, do not change name inside it
+            AddFeature(ArchivesAsFilesFlag); // write out symbolic links to files
+            AddFeature(SymlinkStringInput); // Path to add to symbolic link in linux
             //AddFeature(SharedInputs.TorrentZpaqFlag);
             //AddFeature(SharedInputs.TorrentZstdFlag);
 
@@ -71,6 +74,9 @@ namespace SabreTools.Features
             bool inverse = GetBoolean(features, InverseValue);
             bool quickScan = GetBoolean(features, QuickValue);
             bool updateDat = GetBoolean(features, UpdateDatValue);
+            bool baseReplace = GetBoolean(features, BaseReplaceValue);
+            bool archivesAsFiles = GetBoolean(features, ArchivesAsFilesValue);
+            string symlinkDir = GetString(features, SymlinkDirStringValue);
             var outputFormat = GetOutputFormat(features);
 
             // If we have the romba flag
@@ -108,9 +114,9 @@ namespace SabreTools.Features
                     // If we have the depot flag, respect it
                     bool success;
                     if (Header.InputDepot?.IsActive ?? false)
-                        success = Rebuilder.RebuildDepot(datdata, Inputs, Path.Combine(OutputDir, datdata.Header.FileName), date, delete, inverse, outputFormat);
+                        success = Rebuilder.RebuildDepot(datdata, Inputs, Path.Combine(OutputDir, datdata.Header.FileName), date, delete, inverse, baseReplace, archivesAsFiles, symlinkDir, outputFormat);
                     else
-                        success = Rebuilder.RebuildGeneric(datdata, Inputs, Path.Combine(OutputDir, datdata.Header.FileName), quickScan, date, delete, inverse, outputFormat, asFiles);
+                        success = Rebuilder.RebuildGeneric(datdata, Inputs, Path.Combine(OutputDir, datdata.Header.FileName), quickScan, date, delete, inverse, baseReplace, archivesAsFiles, symlinkDir, outputFormat, asFiles);
 
                     // If we have a success and we're updating the DAT, write it out
                     if (success && updateDat)
@@ -149,9 +155,9 @@ namespace SabreTools.Features
                 // If we have the depot flag, respect it
                 bool success;
                 if (Header.InputDepot?.IsActive ?? false)
-                    success = Rebuilder.RebuildDepot(datdata, Inputs, OutputDir, date, delete, inverse, outputFormat);
+                    success = Rebuilder.RebuildDepot(datdata, Inputs, OutputDir, date, delete, inverse, baseReplace, archivesAsFiles, symlinkDir, outputFormat);
                 else
-                    success = Rebuilder.RebuildGeneric(datdata, Inputs, OutputDir, quickScan, date, delete, inverse, outputFormat, asFiles);
+                    success = Rebuilder.RebuildGeneric(datdata, Inputs, OutputDir, quickScan, date, delete, inverse, baseReplace, archivesAsFiles, symlinkDir, outputFormat, asFiles);
 
                 // If we have a success and we're updating the DAT, write it out
                 if (success && updateDat)


### PR DESCRIPTION
`ss -br -del -t7z`
`-br` Replace Name - Feature that is already there, but used to rename Files after given DAT File
I take No-Intro DAT Files as input to TOSEC game files. With this option they where sorted out and get 
<name of No-Intro>.7z with inside <TOSEC Name>.bin
So its easier to identify them. Every File staying inside the TOSEC Folder was not duplicated with No-Intro files.

`ss -aaf -sd=<DIR>`
creates a #Symlinks.txt File from a given mame-softwarelist.xml file. Those symlinks can be copied to linux server and executed on a file directory. The symlinks point to No-Intro or TOSEC or .. files. They can be excuted from mame emulator and did not need to have the correct name inside the archive. The symlinks will have the correct mame name to satisfy mame need for correct names.