### PR TITLE
Error reading sabretools (self-generated) 7z file

### DIFF
--- a/SabreTools.FileTypes/Compress/SevenZip/SevenZipRead.cs
+++ b/SabreTools.FileTypes/Compress/SevenZip/SevenZipRead.cs
@@ -73,6 +73,7 @@ namespace Compress.SevenZip
         {
             try
             {
+
                 SignatureHeader signatureHeader = new SignatureHeader();
                 if (!signatureHeader.Read(_zipFs))
                 {
@@ -87,7 +88,13 @@ namespace Compress.SevenZip
                 if (!CRC.VerifyDigest(signatureHeader.NextHeaderCRC, mainHeader, 0, (uint)signatureHeader.NextHeaderSize))
                     return ZipReturn.Zip64EndOfCentralDirError;
 
-                if (signatureHeader.NextHeaderSize != 0)
+                ZipStatus = ZipStatus.None;
+                ZipStatus |= IsRomVault7Z(_baseOffset, signatureHeader.NextHeaderOffset, signatureHeader.NextHeaderSize, signatureHeader.NextHeaderCRC) ? ZipStatus.TrrntZip : ZipStatus.None;
+
+                _zipFs.Seek(_baseOffset + (long)(signatureHeader.NextHeaderOffset + signatureHeader.NextHeaderSize), SeekOrigin.Begin);
+                ZipStatus |= Istorrent7Z() ? ZipStatus.Trrnt7Zip : ZipStatus.None;
+
+               if (signatureHeader.NextHeaderSize != 0)
                 {
                     _zipFs.Seek(_baseOffset + (long)signatureHeader.NextHeaderOffset, SeekOrigin.Begin);
                     ZipReturn zr = Header.ReadHeaderOrPackedHeader(_zipFs, _baseOffset, out _header);
@@ -97,12 +104,6 @@ namespace Compress.SevenZip
                     }
                 }
 
-
-                ZipStatus = ZipStatus.None;
-                ZipStatus |= IsRomVault7Z(_baseOffset, signatureHeader.NextHeaderOffset, signatureHeader.NextHeaderSize, signatureHeader.NextHeaderCRC) ? ZipStatus.TrrntZip : ZipStatus.None;
-
-                _zipFs.Seek(_baseOffset + (long)(signatureHeader.NextHeaderOffset + signatureHeader.NextHeaderSize), SeekOrigin.Begin);
-                ZipStatus |= Istorrent7Z() ? ZipStatus.Trrnt7Zip : ZipStatus.None;
                 PopulateLocalFiles(out _localFiles);
 
                 return ZipReturn.ZipGood;


### PR DESCRIPTION
Header.ReadHeaderOrPackedHeader() - BinaryReader call destroys _zipFs stream. 
Error is cannot access closed stream on IsRomVault7Z() call.
Putting Header.ReadHeaderOrPackedHeader() behind IsRomVault7Z() solves error.