### PR TITLE
Setting to NULL ensures first sort of bucketby

### DIFF
--- a/SabreTools.DatTools/Parser.cs
+++ b/SabreTools.DatTools/Parser.cs
@@ -100,7 +100,7 @@ namespace SabreTools.DatTools
             // If the output type isn't set already, get the internal output type
             DatFormat currentPathFormat = GetDatFormat(currentPath);
             datFile.Header.DatFormat = datFile.Header.DatFormat == 0 ? currentPathFormat : datFile.Header.DatFormat;
-            datFile.Items.SetBucketedBy(ItemKey.CRC); // Setting this because it can reduce issues later
+            datFile.Items.SetBucketedBy(ItemKey.NULL); // Setting this because it can reduce issues later, must be NULL to ensure first sorting
             
             InternalStopwatch watch = new InternalStopwatch($"Parsing '{currentPath}' into internal DAT");
 


### PR DESCRIPTION
CRC is default setting, so itemdictionary.cs if (bucketedBy != bucketBy && bucketBy != ItemKey.NULL) is not accessed
with setting to NULL the statement worked and first sort is done. #61 