### PR TITLE
Addasfiles

### DIFF
--- a/SabreTools/Features/BaseFeature.cs
+++ b/SabreTools/Features/BaseFeature.cs
@@ -163,6 +163,20 @@ namespace SabreTools.Features
                     longDescription: "Normally, CHDs would be processed using their internal hash to compare against the input DATs. This flag forces all CHDs to be treated like regular files.");
             }
         }
+        
+        internal const string AddAsFilesValue = "add-as-files";
+        internal static Feature AddAsFilesFlag
+        {
+            get
+            {
+                return new Feature(
+                    AddAsFilesValue,
+                    new List<string>() { "-adaf", "--add-as-files" },
+                    "Treat Archives as regular files and process internal files",
+                    ParameterType.Flag,
+                    longDescription: "Instead of trying to enumerate the files within archives, treat the archives as files themselves and also the inside files. This is good for uncompressed sets that include archives that should be read as-is and also have a hash for the whole file.");
+            }
+        }
 
         internal const string CleanValue = "clean";
         internal static Feature CleanFlag

--- a/SabreTools/Features/DatFromDir.cs
+++ b/SabreTools/Features/DatFromDir.cs
@@ -38,6 +38,7 @@ namespace SabreTools.Features
             AddFeature(AaruFormatsAsFilesFlag);
             AddFeature(ArchivesAsFilesFlag);
             AddFeature(ChdsAsFilesFlag);
+            AddFeature(AddAsFilesFlag);
             AddFeature(OutputTypeListInput);
             this[OutputTypeListInput].AddFeature(DeprecatedFlag);
             AddFeature(RombaFlag);
@@ -64,6 +65,7 @@ namespace SabreTools.Features
             bool addFileDates = GetBoolean(features, AddDateValue);
             TreatAsFile asFiles = GetTreatAsFiles(features);
             bool noAutomaticDate = GetBoolean(features, NoAutomaticDateValue);
+            bool addAsFiles = GetBoolean(features, AddAsFilesValue);
             var includeInScan = GetIncludeInScan(features);
             var skipFileType = GetSkipFileType(features);
 
@@ -92,6 +94,7 @@ namespace SabreTools.Features
                         datdata,
                         basePath,
                         asFiles,
+                        addAsFiles,
                         skipFileType,
                         addBlankFiles,
                         hashes: includeInScan);


### PR DESCRIPTION
To find same files in a chd, you need to have all files (getchildren()) in the machine/rom set. To find the ISO itself and not loop through all children, you need to have the ISO file in the rom set as well. 
This feature add all files and the ISO file itself to the machine/rom set.