### PR TITLE
fix: Allow optional `mia` attribute in `rom` element

### DIFF
--- a/SabreTools.Core/Enums.cs
+++ b/SabreTools.Core/Enums.cs
@@ -553,6 +553,7 @@ namespace SabreTools.Core
         Status,
         Optional,
         Inverted,
+        MIA,
 
         // Rom (Archive.org)
         ArchiveDotOrgSource,

--- a/SabreTools.DatFiles/Formats/Logiqx.cs
+++ b/SabreTools.DatFiles/Formats/Logiqx.cs
@@ -605,6 +605,7 @@ namespace SabreTools.DatFiles.Formats
                             ItemStatus = reader.GetAttribute("status").AsItemStatus(),
                             Date = CleanDate(reader.GetAttribute("date")),
                             Inverted = reader.GetAttribute("inverted").AsYesNo(),
+                            MIA = reader.GetAttribute("mia").AsYesNo(),
 
                             Source = new Source
                             {
@@ -1088,6 +1089,7 @@ namespace SabreTools.DatFiles.Formats
                     xtw.WriteOptionalAttributeString("date", rom.Date);
                     xtw.WriteOptionalAttributeString("status", rom.ItemStatus.FromItemStatus(false));
                     xtw.WriteOptionalAttributeString("inverted", rom.Inverted.FromYesNo());
+                    xtw.WriteOptionalAttributeString("mia", rom.MIA.FromYesNo());
                     xtw.WriteEndElement();
                     break;
 

--- a/SabreTools.DatFiles/Setter.cs
+++ b/SabreTools.DatFiles/Setter.cs
@@ -1081,7 +1081,7 @@ namespace SabreTools.DatFiles
 
             if (DatItemMappings.Keys.Contains(DatItemField.Date))
                 rom.Date = DatItemMappings[DatItemField.Date];
-
+            
             if (DatItemMappings.Keys.Contains(DatItemField.Status))
                 rom.ItemStatus = DatItemMappings[DatItemField.Status].AsItemStatus();
 
@@ -1090,6 +1090,9 @@ namespace SabreTools.DatFiles
 
             if (DatItemMappings.Keys.Contains(DatItemField.Inverted))
                 rom.Inverted = DatItemMappings[DatItemField.Optional].AsYesNo();
+            
+            if (DatItemMappings.Keys.Contains(DatItemField.MIA))
+                rom.MIA = DatItemMappings[DatItemField.MIA].AsYesNo();
 
             #endregion
 

--- a/SabreTools.DatItems/Formats/Rom.cs
+++ b/SabreTools.DatItems/Formats/Rom.cs
@@ -154,6 +154,7 @@ namespace SabreTools.DatItems.Formats
         [JsonConverter(typeof(StringEnumConverter))]
         public ItemStatus ItemStatus { get; set; }
 
+       
         [JsonIgnore]
         public bool ItemStatusSpecified { get { return ItemStatus != ItemStatus.NULL && ItemStatus != ItemStatus.None; } }
 
@@ -171,6 +172,12 @@ namespace SabreTools.DatItems.Formats
         /// </summary>
         [JsonProperty("inverted", DefaultValueHandling = DefaultValueHandling.Ignore), XmlElement("inverted")]
         public bool? Inverted { get; set; } = null;
+
+        /// <summary>
+        /// Rom MIA status
+        /// </summary>
+        [JsonProperty("mia", DefaultValueHandling = DefaultValueHandling.Ignore), XmlElement("mia")]
+        public bool? MIA { get; set; } = null;
 
         [JsonIgnore]
         public bool InvertedSpecified { get { return Inverted != null; } }
@@ -428,6 +435,7 @@ namespace SabreTools.DatItems.Formats
                 ItemStatus = this.ItemStatus,
                 Optional = this.Optional,
                 Inverted = this.Inverted,
+                MIA = this.MIA,
 
                 AltName = this.AltName,
                 AltTitle = this.AltTitle,

--- a/SabreTools.Filtering/DatItemFilter.cs
+++ b/SabreTools.Filtering/DatItemFilter.cs
@@ -43,6 +43,8 @@ namespace SabreTools.Filtering
         public FilterItem<ItemStatus> Status { get; private set; } = new FilterItem<ItemStatus>() { Positive = ItemStatus.NULL, Negative = ItemStatus.NULL };
         public FilterItem<bool?> Optional { get; private set; } = new FilterItem<bool?>() { Neutral = null };
         public FilterItem<bool?> Inverted { get; private set; } = new FilterItem<bool?>();
+        
+        public FilterItem<bool?> MIA { get; private set; } = new FilterItem<bool?>();
 
         // Rom (Archive.org)
         public FilterItem<string> ArchiveDotOrgSource { get; private set; } = new FilterItem<string>();
@@ -1815,6 +1817,10 @@ namespace SabreTools.Filtering
 
             // Filter on inverted
             if (!PassBoolFilter(Inverted, rom.Inverted))
+                return false;
+            
+            // Filter on MIA
+            if (!PassBoolFilter(MIA, rom.MIA))
                 return false;
 
             #endregion

--- a/SabreTools.Filtering/DatItemRemover.cs
+++ b/SabreTools.Filtering/DatItemRemover.cs
@@ -930,6 +930,9 @@ namespace SabreTools.Filtering
 
             if (DatItemFields.Contains(DatItemField.Inverted))
                 rom.Inverted = null;
+            
+            if (DatItemFields.Contains(DatItemField.MIA))
+                rom.MIA = null;
 
             #endregion
 

--- a/SabreTools.Filtering/Replacer.cs
+++ b/SabreTools.Filtering/Replacer.cs
@@ -919,6 +919,9 @@ namespace SabreTools.Filtering
 
             if (datItemFields.Contains(DatItemField.Inverted))
                 rom.Inverted = newItem.Inverted;
+            
+            if (datItemFields.Contains(DatItemField.MIA))
+                rom.MIA = newItem.MIA;
 
             #endregion
 


### PR DESCRIPTION
Coded to mirror the behaviour of `inverted` (Yes/No). Tested when splitting a DAT with MIA flags set and they are now preserved.

Closes #88 (hopefully)